### PR TITLE
Switch deployment to gh-pages branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,20 +2,18 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,18 +30,14 @@ jobs:
       - name: Build with Astro
         run: npm run build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Deploy to gh-pages branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan gh-pages-temp
+          git rm -rf .
+          cp -r dist/* .
+          touch .nojekyll
+          git add .
+          git commit -m "Deploy from ${{ github.sha }}"
+          git push origin gh-pages-temp:gh-pages --force

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The design system is in `src/styles/global.css` with CSS custom properties for c
 
 ## Deployment
 
-Push to `main` to deploy automatically via GitHub Actions.
+Deployments are automatic: push to `main` triggers a GitHub Actions build that publishes to the `gh-pages` branch. You can also trigger manually via Actions → "Deploy to GitHub Pages" → "Run workflow".
 
 ## Notes
 


### PR DESCRIPTION
Use native git commands to push build output to gh-pages branch. No third-party actions beyond official GitHub ones (checkout, setup-node).