### PR TITLE
Align Pages deploy: canonical apex URL, reproducible CI builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build with Astro
         run: npm run build

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://joelweinberger.us',
+  site: 'https://www.joelweinberger.us',
   output: 'static',
   build: {
     assets: 'assets'

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://www.joelweinberger.us',
+  site: 'https://joelweinberger.us',
   output: 'static',
   build: {
     assets: 'assets'

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-joelweinberger.us
+www.joelweinberger.us


### PR DESCRIPTION
- astro.config.mjs: set `site` to `https://joelweinberger.us` to match `public/CNAME`. Prior value (`www.`) disagreed with the CNAME that GitHub Pages actually uses, producing inconsistent canonical URLs.
- deploy.yml: switch `npm install` to `npm ci` and enable npm cache in `actions/setup-node` for reproducible, faster CI builds.