### PR TITLE
Gitignore personal/machine-local Claude Code paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 /dist
 /node_modules
 /.astro
+
+# Claude Code — personal/machine-local
+.claude/settings.local.json
+.claude/worktrees/
+CLAUDE.local.md


### PR DESCRIPTION
Keep team-shared .claude/ contents in the repo, but exclude the per-user settings override, ephemeral worktree sessions, and personal CLAUDE.local.md notes.