### PR TITLE
Deep-link homepage highlights to their publications page entry

### DIFF
--- a/src/lib/publications.ts
+++ b/src/lib/publications.ts
@@ -163,6 +163,18 @@ export function sortByYear(paperList: Paper[]): Paper[] {
 }
 
 /**
+ * Stable DOM id for deep-linking to a paper on the publications page.
+ * Uses the BibTeX `proceedings` key when present, otherwise slugifies the title.
+ */
+export function getPaperId(paper: Paper): string {
+  if (paper.proceedings) return paper.proceedings;
+  return paper.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
  * Get featured papers for homepage highlights
  */
 export function getFeaturedPapers(): Paper[] {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import {
   formatAuthorsWithPrefix,
   getShortVenue,
   getSlidesUrl,
+  getPaperId,
 } from '../lib/publications';
 
 const featuredPapers = getFeaturedPapers();
@@ -81,6 +82,7 @@ const sriPub = getSriSpec();
             </h3>
             <p class="publication-meta">
               {formatAuthorsWithPrefix(paper.authors)} &middot; {getShortVenue(paper.conference || '')}
+              &middot; <a href={`/publications#${getPaperId(paper)}`} class="details-link">Details &rarr;</a>
             </p>
           </article>
         ))}
@@ -92,6 +94,7 @@ const sriPub = getSriSpec();
             </h3>
             <p class="publication-meta">
               {formatAuthorsWithPrefix(sriPub.authors)} &middot; W3C Recommendation
+              &middot; <a href={`/publications#${getPaperId(sriPub)}`} class="details-link">Details &rarr;</a>
             </p>
           </article>
         )}

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -14,6 +14,7 @@ import {
   getYear,
   generateBibtex,
   sortByYear,
+  getPaperId,
 } from '../lib/publications';
 
 const sortedPapers = sortByYear(papers);
@@ -46,7 +47,7 @@ const totalPubs = papers.length + techs.length;
 
       <div class="publications-list">
         {sortedPapers.map(paper => (
-          <article class="publication-card" data-year={getYear(paper)} data-type="refereed">
+          <article class="publication-card" id={getPaperId(paper)} data-year={getYear(paper)} data-type="refereed">
             <div class="pub-header">
               <div>
                 <h3 class="publication-title">
@@ -119,7 +120,7 @@ const totalPubs = papers.length + techs.length;
 
       <div class="publications-list">
         {sortedTechs.map(paper => (
-          <article class="publication-card" data-year={getYear(paper)} data-type="technical">
+          <article class="publication-card" id={getPaperId(paper)} data-year={getYear(paper)} data-type="technical">
             <div class="pub-header">
               <div>
                 <h3 class="publication-title">
@@ -217,6 +218,22 @@ const totalPubs = papers.length + techs.length;
         }
       });
     });
+
+    // Deep-link highlight: flash the card matching the current hash
+    function highlightFromHash() {
+      const hash = window.location.hash.slice(1);
+      if (!hash) return;
+      const target = document.getElementById(hash);
+      if (!target?.classList.contains('publication-card')) return;
+
+      target.classList.remove('highlight');
+      void (target as HTMLElement).offsetWidth;
+      target.classList.add('highlight');
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    highlightFromHash();
+    window.addEventListener('hashchange', highlightFromHash);
 
     // Search with debounce
     const searchInput = document.getElementById('pub-search') as HTMLInputElement;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -386,6 +386,33 @@ a:hover {
   color: var(--color-text-tertiary);
 }
 
+.details-link {
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+  white-space: nowrap;
+}
+
+.details-link:hover {
+  color: var(--color-accent-primary);
+}
+
+@keyframes publication-card-highlight {
+  0%   { box-shadow: 0 0 0 3px var(--color-accent-primary); }
+  100% { box-shadow: none; }
+}
+
+.publication-card.highlight {
+  animation: publication-card-highlight 2.5s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .publication-card.highlight {
+    animation: none;
+    box-shadow: 0 0 0 3px var(--color-accent-primary);
+  }
+}
+
 .publication-authors {
   margin: 0 0 var(--space-2);
   font-size: var(--text-sm);


### PR DESCRIPTION
## Summary
- Each Publication Highlight on the homepage now gets a "Details →" link next to the meta line that points to `/publications#<id>`.
- The publications page flashes an accent outline around the matching card on load / hashchange so visitors can find it immediately, then the glow fades. The main paper title keeps its existing link to the PDF.
- Card IDs come from a new `getPaperId()` helper: BibTeX `proceedings` key when present, otherwise slugified title (covers the SRI spec, which has no `proceedings`).
- Highlight animation respects `prefers-reduced-motion` (static outline instead of the flash).

## Test plan
- [x] `npm run dev`, load `/`, click "Details →" on each highlight (4 total, including SRI). Confirm it scrolls to the right card on `/publications` and the card briefly glows.
- [x] Reload `/publications#barth09heapgraph` directly — same flash-on-load behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)