### PR TITLE
Bump GitHub Actions to Node 24–compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
Resolves the `Node.js 20 actions are deprecated` warnings on every workflow run. GitHub forces Node 24 on June 2, 2026 and removes Node 20 on Sept 16, 2026.

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | node24 |
| `actions/setup-node` | v4 | v6 | node24 |
| `actions/upload-pages-artifact` | v3 | v5 | composite → `upload-artifact@v7` (node24) |
| `actions/deploy-pages` | v4 | v5 | node24 |

All four are the current latest majors (verified via `gh api`, released between March and April 2026). No inputs or outputs changed between these majors for how we use them — `setup-node` still reads `node-version-file: .nvmrc` and `upload-pages-artifact` still takes `path`.

## Test plan
- [ ] Merge and confirm the next deploy runs cleanly on `main` with no Node 20 deprecation annotations.
- [ ] Confirm `www.joelweinberger.us` serves the expected content after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)