### PR TITLE
Update Keybase proof to www.joelweinberger.us

### DIFF
--- a/public/.well-known/keybase.txt
+++ b/public/.well-known/keybase.txt
@@ -4,7 +4,7 @@ https://keybase.io/metromoxie
 
 I hereby claim:
 
-  * I am an admin of https://joelweinberger.us
+  * I am an admin of https://www.joelweinberger.us
   * I am metromoxie (https://keybase.io/metromoxie) on keybase.
   * I have a public key ASDnCPdF1IeAQQL7s_xwQz1pc9TZHVmIHzu2__hDVdr31Qo
 
@@ -20,14 +20,14 @@ To do so, I am signing this object:
       "username": "metromoxie"
     },
     "merkle_root": {
-      "ctime": 1716612142,
-      "hash": "23149ee75cec87c2c66227127e5facfed3df76029a71693f97975fc9156ede2f4b1d48d7f52c088bfd1f88d73224bba1a3e6c09c4cb41847703c2ce5416635d2",
-      "hash_meta": "eee39dd46b0fe8eda41f10f3a3e3d671527fcec1ccc89d4111be9ef720796446",
-      "seqno": 25757576
+      "ctime": 1776630044,
+      "hash": "4a8b1e15786c5b7c97497eb230e96f725ad5fb8f7073aa5e66ea4e852cea713cb4a03d7dc81252561224f73dc9db4ebf4ebb6b701754025cf6ccbe1fe9f6b433",
+      "hash_meta": "9a450de41b321777849157fbf2c27b428e83eeac8010baf021c77116c8e31727",
+      "seqno": 27537486
     },
     "service": {
-      "entropy": "DFpe+wrQalH6G1m5WevjV5PN",
-      "hostname": "joelweinberger.us",
+      "entropy": "hHfriYf7n7sNapqnMduh0ikG",
+      "hostname": "www.joelweinberger.us",
       "protocol": "https:"
     },
     "type": "web_service_binding",
@@ -35,18 +35,18 @@ To do so, I am signing this object:
   },
   "client": {
     "name": "keybase.io go client",
-    "version": "6.2.8"
+    "version": "6.5.4"
   },
-  "ctime": 1716612152,
+  "ctime": 1776630199,
   "expire_in": 504576000,
-  "prev": "36ac795fc67d982116bfcec3bfcf9fa39078262fe049dc733db52e57f0aac60d",
-  "seqno": 20,
+  "prev": "3b914d370106ed0307ed46fad07183aee3733cec2f9aa5ad97bbf1a7c2983546",
+  "seqno": 21,
   "tag": "signature"
 }
 
 which yields the signature:
 
-hKRib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg5wj3RdSHgEEC+7P8cEM9aXPU2R1ZiB87tv/4Q1Xa99UKp3BheWxvYWTESpcCFMQgNqx5X8Z9mCEWv87Dv8+fo5B4Ji/gSdxzPbUuV/Cqxg3EILNV4OPjq1fHHDMp/IV0QgtBOM+cD/Vc0bno5awXhRawAgHCo3NpZ8RAZcRblO0aCBm3TvmM856NjVHpQfLHuy9VqxViBFgTwumNs0Kx4k79AQs9/19nHAOQAupVHKw489rPMRBpz675D6hzaWdfdHlwZSCkaGFzaIKkdHlwZQildmFsdWXEIKhE/MGLJzTOjS5fZGAA9P5wjW75WlWtf0yGVgiFeyvho3RhZ80CAqd2ZXJzaW9uAQ==
+hKRib2R5hqhkZXRhY2hlZMOpaGFzaF90eXBlCqNrZXnEIwEg5wj3RdSHgEEC+7P8cEM9aXPU2R1ZiB87tv/4Q1Xa99UKp3BheWxvYWTESpcCFcQgO5FNNwEG7QMH7Ub60HGDruNzPOwvmqWtl7vxp8KYNUbEIOpurPcfwd9U37MHXSdvlofNrdXG8yEWEhlN0HpyGU8XAgHCo3NpZ8RA5n1jcft3fcaUrP6NLG8K9soqZbrHYJu+Xo3eU2gVcKQNFliyORcUvx2lfWygbcCDAWaY8vf8caLAViRT9BSgAahzaWdfdHlwZSCkaGFzaIKkdHlwZQildmFsdWXEIOCgsQSlU1apPQBII4cEVXpmC2zRJ2A2BsxXPgtKjm4Po3RhZ80CAqd2ZXJzaW9uAQ==
 
 And finally, I am proving ownership of this host by posting or
 appending to this document.


### PR DESCRIPTION
## Summary
- Replaces `public/.well-known/keybase.txt` with a newly signed proof bound to `www.joelweinberger.us` (verified `service.hostname` in the signed JSON).
- Fixes the "proof missing" notification from Keybase: the old proof was signed against the apex `joelweinberger.us`, but since #16 the canonical host is `www` and GitHub Pages redirects apex → www. Keybase doesn't follow redirects when verifying, so the old proof stopped resolving.

## Test plan
- [ ] After merge and Pages deploy, confirm `https://www.joelweinberger.us/.well-known/keybase.txt` returns the new content with `200` (no redirect).
- [ ] In the Keybase client / on keybase.io/metromoxie, trigger a recheck of the `www.joelweinberger.us` proof and confirm it verifies.

https://claude.ai/code/session_01TNsGFDezi5vWqUUVkajb8t