### PR TITLE
Include hidden files in Pages artifact so .well-known/ deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
+          include-hidden-files: true
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
Follow-up to #27. The Keybase proof was committed and built, but the live site still 404s `/.well-known/keybase.txt` because `actions/upload-pages-artifact@v5` now defaults `include-hidden-files: false`, which passes `--exclude=.[^/]*` to tar and strips every top-level dot-prefixed entry from the artifact — `.well-known/` included.

Evidence from run 24638362254's upload step:
- Tar invocation logs `--exclude=.[^/]*` and `include-hidden-files: false`.
- The tar listing contains no `./.well-known/` entry, even though the Astro build writes `dist/.well-known/keybase.txt`.

Setting `include-hidden-files: true` on the upload step fixes it.

## Test plan
- [ ] After merge, confirm the deploy workflow run for this commit succeeds.
- [ ] `curl -I https://www.joelweinberger.us/.well-known/keybase.txt` returns `200` (no redirect).
- [ ] Trigger a Keybase recheck of the `www.joelweinberger.us` proof and confirm it verifies.

https://claude.ai/code/session_01TNsGFDezi5vWqUUVkajb8t