### PR TITLE
TEST: verify CI gate blocks merge — DO NOT MERGE

### DIFF
--- a/src/lib/publications.ts
+++ b/src/lib/publications.ts
@@ -1,7 +1,7 @@
 /**
  * Shared utilities for working with publication data
  */
-import pubs from '../../pubs.json';
+import pubs from '../../this-file-does-not-exist.json'; // intentional break to test CI gate — DO NOT MERGE
 
 export interface Author {
   name: string;


### PR DESCRIPTION
## Purpose

Sanity-check that the **CI / build** status check from #29 blocks the merge button when the build fails. **Do not merge.** Close after verifying.

## What's broken

`src/lib/publications.ts` line 4: import path swapped to a file that doesn't exist. `npm run build` fails locally with:

```
[ERROR] [vite] ✗ Build failed
Could not resolve "../../this-file-does-not-exist.json" from "src/lib/publications.ts"
```

## What you should see

- The **CI / build** check appears on this PR and fails (red ✗).
- If the branch protection rule on `main` requires the **CI / build** check, the merge button is disabled with "Required status check has failed."
- If the merge button is *not* disabled, the required-check rule isn't set yet — fix that in **Settings → Branches → main → branch protection rule** before relying on the gate.

After you've confirmed the gate works, close this PR (no merge) and delete `claude/ci-gate-test-do-not-merge`.