### PR TITLE
Redesign 2026: paper theme, Source Serif, year-gutter publications timeline

### DIFF
--- a/pubs.json
+++ b/pubs.json
@@ -214,6 +214,7 @@
 	  "title": "Subresource Integrity (W3C Specification)",
 	  "pdf": "https://www.w3.org/TR/SRI/",
 	  "authors": [ "devdatta", "freddyb", "francoism", "jww" ],
+	  "year": "2016",
 	  "nobibtex": true
 	}
   ]

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * Reusable page header with back link and title
- * Used on sub-pages like Publications, Calendar, Wedding
+ * Used on sub-pages (Calendar, Wedding).
  */
 interface Props {
   title: string;
@@ -11,18 +11,11 @@ const { title } = Astro.props;
 ---
 
 <header class="page-header">
-  <div class="container">
-    <div class="header-content">
-      <div class="header-left">
-        <a href="/" class="back-link">
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-            <path d="M10 12L6 8L10 4"/>
-          </svg>
-          Home
-        </a>
-        <h1 class="page-title">{title}</h1>
-        <slot />
-      </div>
+  <div class="header-content">
+    <div class="header-left">
+      <a href="/" class="back-link">← Home</a>
+      <h1 class="page-title">{title}</h1>
+      <slot />
     </div>
   </div>
 </header>

--- a/src/components/SimpleFooter.astro
+++ b/src/components/SimpleFooter.astro
@@ -4,27 +4,6 @@
  */
 ---
 
-<footer class="footer">
-  <div class="container">
-    <p class="footer-text">
-      <a href="/">Back to home</a>
-    </p>
-  </div>
+<footer class="subpage-footer">
+  <a href="/">← Back to home</a>
 </footer>
-
-<style>
-  .footer-text {
-    font-size: var(--text-sm);
-    color: var(--color-text-tertiary);
-    margin: 0;
-  }
-
-  .footer-text a {
-    color: var(--color-accent-primary);
-    text-decoration: none;
-  }
-
-  .footer-text a:hover {
-    text-decoration: underline;
-  }
-</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,7 +26,10 @@ const ogImage = new URL(image, Astro.site).toString();
   <title>{title}</title>
   <link rel="canonical" href={canonical}>
   <link rel="icon" type="image/x-icon" href="/img/lock.ico">
-  <link rel="stylesheet" href="/fonts/fonts.css">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,400;0,600;1,400&family=Inter+Tight:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content={canonical}>

--- a/src/lib/publications.ts
+++ b/src/lib/publications.ts
@@ -151,6 +151,22 @@ export function getShortVenue(conference: string): string {
 }
 
 /**
+ * Compact venue tag for the homepage's inline pill — short enough to sit on
+ * the same line as the paper title. Prefers a parenthesized acronym
+ * (e.g. "ESORICS", "HotSec") plus the 2-digit year; falls back to
+ * `getShortVenue` for venues that don't carry an abbreviation.
+ */
+export function getCompactVenue(conference: string): string {
+  if (!conference) return '';
+  const stripped = conference.replace(/^In Proc\. of /, '');
+  const yearMatch = stripped.match(/\d{4}/);
+  const yearShort = yearMatch ? `'${yearMatch[0].slice(2)}` : '';
+  const acronym = stripped.match(/\(([A-Z][A-Za-z0-9]{1,12})\)/);
+  if (acronym) return yearShort ? `${acronym[1]} ${yearShort}` : acronym[1];
+  return getShortVenue(conference).replace(/(\d{4})$/, "'$1").replace(/'(\d{2})(\d{2})$/, "'$2");
+}
+
+/**
  * Get paper year, returns empty string if not available
  */
 export function getYear(paper: Paper): string {

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -7,9 +7,9 @@ import SimpleFooter from '../components/SimpleFooter.astro';
 <BaseLayout title="Calendar - Joel Weinberger" description="Joel Weinberger's public calendar">
   <PageHeader title="Calendar" />
 
-  <main class="container">
-    <section class="calendar-section">
-      <p class="calendar-intro">
+  <main class="subpage-shell">
+    <section class="prose">
+      <p>
         My public availability, embedded from Google Calendar. If the embed doesn't load, you can also
         <a href="https://calendar.google.com/calendar/u/0?cid=am9lbC53ZWluYmVyZ2VyQGdtYWlsLmNvbQ" rel="noopener noreferrer">view it directly on Google Calendar</a>.
       </p>
@@ -25,19 +25,12 @@ import SimpleFooter from '../components/SimpleFooter.astro';
 </BaseLayout>
 
 <style>
-  .calendar-section {
-    padding: var(--space-8) 0;
-  }
-
-  .calendar-intro {
-    color: var(--color-text-secondary);
-    margin: 0 0 var(--space-4);
-  }
-
   #calendar {
     width: 100%;
     height: 600px;
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
+    border: 1px solid var(--paper-rule);
+    border-radius: 2px;
+    margin-top: 1rem;
+    background: #fff;
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,162 +5,136 @@ import {
   getSriSpec,
   getPdfUrl,
   formatAuthorsWithPrefix,
-  getShortVenue,
-  getSlidesUrl,
-  getPaperId,
+  getCompactVenue,
+  getYear,
   safeHref,
 } from '../lib/publications';
 
-const featuredPapers = getFeaturedPapers();
-const sriPub = getSriSpec();
+/* Featured papers + the SRI spec, sorted newest first. The W3C SRI Recommendation
+   is dated 2016 in pubs.json so it lands at the top of the highlight list. */
+const featured = getFeaturedPapers();
+const sri = getSriSpec();
+const highlights = [...featured, ...(sri ? [sri] : [])].sort((a, b) => {
+  return parseInt(getYear(b) || '0') - parseInt(getYear(a) || '0');
+});
 ---
 
 <BaseLayout title="Joel Weinberger">
-  <!-- HERO SECTION -->
-  <header class="hero">
-    <div class="container">
-      <div class="hero-title">
-        <h1>Joel Weinberger</h1>
+  <div class="page">
+    <div class="shell">
+      <div class="topbar">
+        <a href="/" class="marque">jww</a>
+        <nav>
+          <a href="/" aria-current="page">Home</a>
+          <a href="/publications">Publications</a>
+          <a href="/resume.pdf">Résumé</a>
+          <a href="https://github.com/joelweinberger" rel="noopener noreferrer">GitHub</a>
+        </nav>
+      </div>
+
+      <header class="hero">
+        <div class="hero-text">
+          <h1><span class="given">Joel</span><em>Weinberger</em></h1>
+          <p class="hero-lede">
+            Security engineer in Los Angeles. I focus on the security of how we build systems — web platform security, supply-chain security, and developer security.
+          </p>
+        </div>
         <img
           src="/img/joel-weinberger-headshot.jpg"
           alt="Joel Weinberger"
-          class="profile-image"
-          width="100"
-          height="125"
+          class="headshot"
+          width="140"
+          height="175"
         />
-      </div>
+      </header>
 
-      <nav class="quick-nav">
-        <a href="/publications" class="nav-link">Publications</a>
-        <a href="/resume.pdf" class="nav-link">Resume</a>
-        <a href="https://github.com/joelweinberger" class="nav-link" rel="noopener noreferrer">GitHub</a>
-      </nav>
+      <section class="section" id="about">
+        <div class="section-label">
+          <h2>About</h2>
+          <span class="meta">Bio</span>
+        </div>
+        <div class="prose">
+          <p>
+            Currently, I work on security engineering at <a href="https://www.anthropic.com" rel="noopener noreferrer">Anthropic</a>. Previously, I led security engineering at <a href="https://www.lightspark.com/" rel="noopener noreferrer">Lightspark</a> and managed supply-chain security at <a href="https://www.snap.com" rel="noopener noreferrer">Snap</a>. Before that, I was on the <a href="https://www.chromium.org/Home/chromium-security" rel="noopener noreferrer">Chrome Security</a> team at Google.
+          </p>
+          <p>
+            I hold a Ph.D. from <a href="https://www.berkeley.edu/" rel="noopener noreferrer">UC Berkeley</a>, where I worked with <a href="https://www.cs.berkeley.edu/~dawnsong/" rel="noopener noreferrer">Dawn Song</a> on web application security — making the web safer through better security policies and analysis tools. Our group's work lives at <a href="https://webblaze.cs.berkeley.edu/" rel="noopener noreferrer">WebBlaze</a>.
+          </p>
+          <p>
+            Earlier still, B.S. and M.S. from <a href="https://www.brown.edu" rel="noopener noreferrer">Brown University</a>, with stops at Sun Microsystems and Microsoft Research along the way.
+          </p>
+        </div>
+      </section>
+
+      <section class="section" id="work">
+        <div class="section-label prominent">
+          <h2>Publications</h2>
+        </div>
+
+        <ul class="pub-list">
+          {highlights.map(p => {
+            const pdfUrl = getPdfUrl(p);
+            const isExternal = p.pdf.startsWith('http');
+            const venue = p.conference ? getCompactVenue(p.conference) : 'W3C Recommendation';
+            const coauthors = formatAuthorsWithPrefix(p.authors);
+            return (
+              <li class="pub">
+                <div class="pub-year">{getYear(p)}</div>
+                <div class="pub-body">
+                  <h3 class="pub-title">
+                    <a href={safeHref(pdfUrl)} rel={isExternal ? 'noopener noreferrer' : undefined}>{p.title.replace(' (W3C Specification)', '')}</a>
+                    <span class="pub-venue-inline">{venue}</span>
+                  </h3>
+                  {coauthors && <p class="pub-meta">{coauthors}</p>}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+
+        <a class="see-more" href="/publications">All publications</a>
+      </section>
+
+      <section class="section" id="outside">
+        <div class="section-label">
+          <h2>Outside work</h2>
+          <span class="meta">Personal</span>
+        </div>
+        <div class="prose">
+          <p>
+            Most of my time outside work is spent with my three kids and wonderful wife. I run to decompress, and I <a href="https://www.mammothmountain.com" rel="noopener noreferrer">ski</a>, snowboard, and surf whenever possible (bless SoCal weather and geography). I still <a href="https://www.touchstoneclimbing.com" rel="noopener noreferrer">rock climb</a> occasionally, though not as much as I'd like — and I am a nearly life-long tap dancer.
+          </p>
+          <p>
+            My main entertainment is <a href="https://www.goodreads.com/user/show/3465980-joel-weinberger" rel="noopener noreferrer">reading</a> and a bit of video gaming. As a historical drop, you can view a <a href="/wedding">retrospective on my wedding</a>.
+          </p>
+          <p style="font-size: 0.92rem; color: var(--ink-faint);">
+            For nostalgia: my <a href="/brown-cs-website/index.html">old Brown CS homepage</a> from a previous internet.
+          </p>
+        </div>
+      </section>
+
+      <footer class="colophon">
+        <a href="https://www.newarknj.gov/" class="newark-link" rel="noopener noreferrer">
+          <img
+            src="/img/greetings from newark.jpg"
+            alt="Greetings from Newark, NJ!"
+            class="newark-img-plain"
+            width="160"
+            loading="lazy"
+          />
+        </a>
+
+        <nav class="colophon-links">
+          <a href="mailto:jww@joelweinberger.us">Email</a>
+          <a href="https://github.com/joelweinberger" rel="noopener noreferrer">GitHub</a>
+          <a href="https://www.linkedin.com/in/joelweinberger" rel="noopener noreferrer">LinkedIn</a>
+          <a href="https://twitter.com/metromoxie" rel="noopener noreferrer">Twitter</a>
+          <a href="/calendar">Calendar</a>
+        </nav>
+        <p class="colophon-credit">
+          <a href="https://github.com/joelweinberger/personal-website" rel="noopener noreferrer">Source on GitHub</a>
+        </p>
+      </footer>
     </div>
-  </header>
-
-  <main class="container">
-    <!-- ABOUT SECTION -->
-    <section class="section">
-      <header class="section-header">
-        <h2 class="section-title">About</h2>
-      </header>
-
-      <div class="bio-content">
-        <p>
-          I work on security engineering at <a href="https://www.anthropic.com" rel="noopener noreferrer">Anthropic</a>.
-          Previously, I led security engineering at <a href="https://www.lightspark.com/" rel="noopener noreferrer">Lightspark</a>
-          and managed supply chain security at <a href="https://www.snap.com" rel="noopener noreferrer">Snap</a>. Before that, I was on
-          the <a href="https://www.chromium.org/Home/chromium-security" rel="noopener noreferrer">Chrome Security</a> team at Google.
-        </p>
-        <p>
-          I hold a Ph.D. from <a href="https://www.berkeley.edu/" rel="noopener noreferrer">UC Berkeley</a>, where I worked with
-          <a href="https://www.cs.berkeley.edu/~dawnsong/" rel="noopener noreferrer">Dawn Song</a> on web application security.
-          My research focused on making the web safer through better security policies and analysis tools.
-          You can find our group's work at <a href="https://webblaze.cs.berkeley.edu/" rel="noopener noreferrer">WebBlaze</a>.
-        </p>
-        <p>
-          I earned my B.S. and M.S. from <a href="https://www.brown.edu" rel="noopener noreferrer">Brown University</a>,
-          and spent time at Sun Microsystems and Microsoft Research along the way. I live and work in Los Angeles, CA. 
-        </p>
-      </div>
-
-      <p class="legacy-note">
-        For nostalgia: my <a href="/brown-cs-website/index.html">old Brown CS homepage</a>
-      </p>
-    </section>
-
-    <!-- PUBLICATION HIGHLIGHTS -->
-    <section class="section">
-      <header class="section-header">
-        <h2 class="section-title">Publication Highlights</h2>
-      </header>
-
-      <div class="publications-list compact">
-        {featuredPapers.map(paper => {
-          const coauthors = formatAuthorsWithPrefix(paper.authors);
-          const pdfUrl = getPdfUrl(paper);
-          const pdfIsExternal = paper.pdf.startsWith('http');
-          return (
-            <article class="publication-card">
-              <h3 class="publication-title">
-                <a href={safeHref(pdfUrl)} rel={pdfIsExternal ? 'noopener noreferrer' : undefined}>{paper.title}</a>
-              </h3>
-              <p class="publication-meta">
-                {coauthors && <>{coauthors} &middot; </>}
-                {getShortVenue(paper.conference || '')}
-                &middot; <a href={`/publications#${getPaperId(paper)}`} class="details-link">Details &rarr;</a>
-              </p>
-            </article>
-          );
-        })}
-
-        {sriPub && (() => {
-          const coauthors = formatAuthorsWithPrefix(sriPub.authors);
-          return (
-            <article class="publication-card">
-              <h3 class="publication-title">
-                <a href={safeHref(sriPub.pdf)} rel="noopener noreferrer">{sriPub.title.replace(' (W3C Specification)', '')}</a>
-              </h3>
-              <p class="publication-meta">
-                {coauthors && <>{coauthors} &middot; </>}
-                W3C Recommendation
-                &middot; <a href={`/publications#${getPaperId(sriPub)}`} class="details-link">Details &rarr;</a>
-              </p>
-            </article>
-          );
-        })()}
-      </div>
-
-      <p class="see-all-link">
-        <a href="/publications">See all publications →</a>
-      </p>
-    </section>
-
-    <!-- PERSONAL SECTION -->
-    <section class="section">
-      <header class="section-header">
-        <h2 class="section-title">Outside Work</h2>
-      </header>
-
-      <div class="bio-content">
-        <p>
-          Most of my time outside work is spent with my three kids and wonderful wife.
-          I run to decompress, and I <a href="https://www.mammothmountain.com" rel="noopener noreferrer">ski</a>, snowboard, and surf whenever possible (bless SoCal weather and geography).
-          I still <a href="https://www.touchstoneclimbing.com" rel="noopener noreferrer">rock climb</a> occasionally,
-          though not as much as I'd like, and I am a nearly life long tap dancer.
-        </p>
-        <p>
-          My main entertainment is <a href="https://www.goodreads.com/user/show/3465980-joel-weinberger" rel="noopener noreferrer">reading</a> and a bit of video gaming.
-        </p>
-        <p>
-          As an historical drop, you can view a <a href="/wedding">retrospective on my wedding</a>.
-        </p>
-      </div>
-    </section>
-  </main>
-
-  <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container">
-      <a href="https://www.newarknj.gov/" class="newark-link" rel="noopener noreferrer">
-        <img
-          src="/img/greetings from newark.jpg"
-          alt="Greetings from Newark, NJ!"
-          class="newark-postcard"
-          width="180"
-          loading="lazy"
-        />
-      </a>
-      <nav class="footer-links">
-        <a href="mailto:jww@joelweinberger.us" class="footer-link">Email</a>
-        <a href="https://github.com/joelweinberger" class="footer-link" rel="noopener noreferrer">GitHub</a>
-        <a href="https://www.linkedin.com/in/joelweinberger" class="footer-link" rel="noopener noreferrer">LinkedIn</a>
-        <a href="https://twitter.com/metromoxie" class="footer-link" rel="noopener noreferrer">Twitter</a>
-        <a href="/calendar" class="footer-link">Calendar</a>
-      </nav>
-      <p class="footer-credit">
-        <a href="https://github.com/joelweinberger/personal-website" rel="noopener noreferrer">Source on GitHub</a>
-      </p>
-    </div>
-  </footer>
+  </div>
 </BaseLayout>

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -1,21 +1,17 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import PageHeader from '../components/PageHeader.astro';
-import SimpleFooter from '../components/SimpleFooter.astro';
 import {
   papers,
   techs,
   getAuthorName,
   getAuthorLink,
   getPdfUrl,
-  getSlidesUrl,
-  getProjectUrl,
   formatVenue,
   getYear,
   generateBibtex,
-  sortByYear,
   getPaperId,
   safeHref,
+  type Paper,
 } from '../lib/publications';
 
 /**
@@ -29,413 +25,104 @@ function authorSeparator(index: number, total: number): string {
   return ', ';
 }
 
-const sortedPapers = sortByYear(papers);
-const sortedTechs = sortByYear(techs);
-const totalPubs = papers.length + techs.length;
+/* Single chronological list — papers + tech reports + the SRI spec, newest first. */
+const all: Paper[] = [...papers, ...techs].sort((a, b) => {
+  return parseInt(getYear(b) || '0') - parseInt(getYear(a) || '0');
+});
 ---
 
 <BaseLayout title="Publications - Joel Weinberger" description="Research publications by Joel Weinberger on web security, browser security, and programming languages.">
-  <PageHeader title="Publications">
-    <span class="pub-count">{totalPubs} papers</span>
-  </PageHeader>
+  <div class="page pubs-page">
+    <div class="shell">
+      <div class="topbar">
+        <a href="/" class="marque">jww</a>
+        <nav>
+          <a href="/">Home</a>
+          <a href="/publications" aria-current="page">Publications</a>
+          <a href="/resume.pdf">Résumé</a>
+          <a href="https://github.com/joelweinberger" rel="noopener noreferrer">GitHub</a>
+        </nav>
+      </div>
 
-  <!-- FILTER BAR -->
-  <div class="container">
-    <div class="filter-bar">
-      <button class="filter-chip active" data-filter="all">All</button>
-      <button class="filter-chip" data-filter="refereed">Refereed</button>
-      <button class="filter-chip" data-filter="technical">Technical Reports</button>
-      <input type="text" class="search-input" placeholder="Search publications..." id="pub-search" aria-label="Search publications">
+      <header style="margin-bottom: clamp(2rem, 5vw, 3rem);">
+        <h1 class="pubs-h1">
+          Papers, specs &amp; <em>tech reports</em>
+        </h1>
+        <p class="pubs-intro">
+          A chronological record of work in browser security, web policy, and program verification — from grad-school proofs to deployed standards. Most pieces are co-authored; my collaborators do the heavy lifting.
+        </p>
+      </header>
+
+      <ol class="timeline">
+        {all.map(p => {
+          const pdfUrl = getPdfUrl(p);
+          const isExternal = p.pdf.startsWith('http');
+          const isSpec = p.pdf.includes('w3.org');
+          const venue = p.conference ? formatVenue(p.conference) : 'W3C Recommendation';
+          const bibtex = generateBibtex(p);
+          return (
+            <li class="tl-row">
+              <div class="year-anchor">{getYear(p)}</div>
+              <article class="tl-paper" id={getPaperId(p)}>
+                <h3 class="tl-title">
+                  <a href={safeHref(pdfUrl)} rel={isExternal ? 'noopener noreferrer' : undefined}>{p.title.replace(' (W3C Specification)', '')}</a>
+                </h3>
+                <p class="tl-meta">
+                  <span class="venue-name">{venue}</span>
+                  {p.authors.length > 1 && (
+                    <>
+                      {' · '}
+                      {p.authors.map((authorId, i) => (
+                        <>
+                          {authorSeparator(i, p.authors.length)}
+                          {authorId === 'jww' ? (
+                            <span>{getAuthorName(authorId)}</span>
+                          ) : getAuthorLink(authorId) ? (
+                            <a href={safeHref(getAuthorLink(authorId))} rel="noopener noreferrer">{getAuthorName(authorId)}</a>
+                          ) : (
+                            <span>{getAuthorName(authorId)}</span>
+                          )}
+                        </>
+                      ))}
+                    </>
+                  )}
+                </p>
+                <div class="tl-actions">
+                  <a href={safeHref(pdfUrl)} rel={isExternal ? 'noopener noreferrer' : undefined}>{isSpec ? 'Specification' : 'PDF'}</a>
+                  {p.abstract && (
+                    <button type="button" class="tl-toggle" data-toggle="abstract" aria-expanded="false">Abstract</button>
+                  )}
+                  {bibtex && (
+                    <button type="button" class="tl-toggle" data-toggle="bibtex" aria-expanded="false">BibTeX</button>
+                  )}
+                </div>
+                {p.abstract && (
+                  <p class="tl-abstract" data-panel="abstract" hidden>{p.abstract}</p>
+                )}
+                {bibtex && (
+                  <pre class="tl-bibtex" data-panel="bibtex" hidden>{bibtex}</pre>
+                )}
+              </article>
+            </li>
+          );
+        })}
+      </ol>
+
+      <footer class="colophon">
+        <nav class="colophon-links">
+          <a href="/">Home</a>
+          <a href="mailto:jww@joelweinberger.us">Email</a>
+          <a href="https://github.com/joelweinberger" rel="noopener noreferrer">GitHub</a>
+          <a href="https://www.linkedin.com/in/joelweinberger" rel="noopener noreferrer">LinkedIn</a>
+        </nav>
+        <p class="colophon-credit">
+          <a href="https://github.com/joelweinberger/personal-website" rel="noopener noreferrer">Source on GitHub</a>
+        </p>
+      </footer>
     </div>
   </div>
-
-  <main class="container">
-    <!-- REFEREED PUBLICATIONS -->
-    <section class="publications-section" data-section="refereed">
-      <div class="section-label">
-        <h2>Refereed Publications</h2>
-        <span class="section-line"></span>
-      </div>
-
-      <div class="publications-list">
-        {sortedPapers.map(paper => {
-          const pdfUrl = getPdfUrl(paper);
-          const pdfIsExternal = paper.pdf.startsWith('http');
-          const slidesUrl = getSlidesUrl(paper);
-          const projectUrl = getProjectUrl(paper);
-          return (
-          <article class="publication-card" id={getPaperId(paper)} data-year={getYear(paper)} data-type="refereed">
-            <div class="pub-header">
-              <div>
-                <h3 class="publication-title">
-                  <a href={safeHref(pdfUrl)} rel={pdfIsExternal ? 'noopener noreferrer' : undefined}>{paper.title}</a>
-                </h3>
-                <p class="publication-authors">
-                  {paper.authors.map((authorId, i) => (
-                    <>
-                      {authorSeparator(i, paper.authors.length)}
-                      {authorId === 'jww' ? (
-                        <span class="self">{getAuthorName(authorId)}</span>
-                      ) : getAuthorLink(authorId) ? (
-                        <a href={safeHref(getAuthorLink(authorId))} rel="noopener noreferrer">{getAuthorName(authorId)}</a>
-                      ) : (
-                        <span>{getAuthorName(authorId)}</span>
-                      )}
-                    </>
-                  ))}
-                </p>
-                <p class="publication-venue">{formatVenue(paper.conference || '')}</p>
-              </div>
-              <span class="pub-year">{getYear(paper)}</span>
-            </div>
-            <div class="publication-actions">
-              <a href={safeHref(pdfUrl)} class="pub-action primary" rel={pdfIsExternal ? 'noopener noreferrer' : undefined}>PDF</a>
-              {paper.abstract && (
-                <button class="pub-action" data-toggle="abstract" aria-expanded="false">Abstract</button>
-              )}
-              {!paper.nobibtex && paper.proceedings && (
-                <button class="pub-action" data-toggle="bibtex" aria-expanded="false">BibTeX</button>
-              )}
-              {slidesUrl && (
-                <a href={safeHref(slidesUrl)} class="pub-action" rel="noopener noreferrer">Slides</a>
-              )}
-              {paper.extended && (
-                <a href={safeHref(`/${paper.extended}`)} class="pub-action">Extended</a>
-              )}
-              {projectUrl && (
-                <a href={safeHref(projectUrl)} class="pub-action" rel="noopener noreferrer">Project</a>
-              )}
-              {paper.citeseer && (
-                <a href={safeHref(paper.citeseer)} class="pub-action" rel="noopener noreferrer">CiteSeer</a>
-              )}
-            </div>
-            {paper.abstract && (
-              <div class="collapsible-content abstract-wrapper" aria-hidden="true">
-                <div class="collapsible-inner">
-                  <div class="abstract-box">{paper.abstract}</div>
-                </div>
-              </div>
-            )}
-            {!paper.nobibtex && paper.proceedings && (
-              <div class="collapsible-content bibtex-wrapper" aria-hidden="true">
-                <div class="collapsible-inner">
-                  <div class="bibtex-box"><code>{generateBibtex(paper)}</code></div>
-                </div>
-              </div>
-            )}
-          </article>
-          );
-        })}
-      </div>
-    </section>
-
-    <!-- TECHNICAL REPORTS -->
-    <section class="publications-section" data-section="technical">
-      <div class="section-label">
-        <h2>Technical Reports & Specifications</h2>
-        <span class="section-line"></span>
-      </div>
-
-      <div class="publications-list">
-        {sortedTechs.map(paper => {
-          const pdfUrl = getPdfUrl(paper);
-          const pdfIsExternal = paper.pdf.startsWith('http');
-          return (
-          <article class="publication-card" id={getPaperId(paper)} data-year={getYear(paper)} data-type="technical">
-            <div class="pub-header">
-              <div>
-                <h3 class="publication-title">
-                  <a href={safeHref(pdfUrl)} rel={pdfIsExternal ? 'noopener noreferrer' : undefined}>{paper.title}</a>
-                </h3>
-                <p class="publication-authors">
-                  {paper.authors.map((authorId, i) => (
-                    <>
-                      {authorSeparator(i, paper.authors.length)}
-                      {authorId === 'jww' ? (
-                        <span class="self">{getAuthorName(authorId)}</span>
-                      ) : getAuthorLink(authorId) ? (
-                        <a href={safeHref(getAuthorLink(authorId))} rel="noopener noreferrer">{getAuthorName(authorId)}</a>
-                      ) : (
-                        <span>{getAuthorName(authorId)}</span>
-                      )}
-                    </>
-                  ))}
-                </p>
-                <p class="publication-venue">{paper.conference || 'W3C Recommendation'}</p>
-              </div>
-              <span class="pub-year">{getYear(paper) || 'W3C'}</span>
-            </div>
-            <div class="publication-actions">
-              <a href={safeHref(pdfUrl)} class="pub-action primary" rel={pdfIsExternal ? 'noopener noreferrer' : undefined}>
-                {paper.pdf.includes('w3.org') ? 'Specification' : 'PDF'}
-              </a>
-              {paper.abstract && (
-                <button class="pub-action" data-toggle="abstract" aria-expanded="false">Abstract</button>
-              )}
-              {!paper.nobibtex && paper.proceedings && (
-                <button class="pub-action" data-toggle="bibtex" aria-expanded="false">BibTeX</button>
-              )}
-            </div>
-            {paper.abstract && (
-              <div class="collapsible-content abstract-wrapper" aria-hidden="true">
-                <div class="collapsible-inner">
-                  <div class="abstract-box">{paper.abstract}</div>
-                </div>
-              </div>
-            )}
-            {!paper.nobibtex && paper.proceedings && (
-              <div class="collapsible-content bibtex-wrapper" aria-hidden="true">
-                <div class="collapsible-inner">
-                  <div class="bibtex-box"><code>{generateBibtex(paper)}</code></div>
-                </div>
-              </div>
-            )}
-          </article>
-          );
-        })}
-      </div>
-    </section>
-  </main>
-
-  <SimpleFooter />
 
   <script>
     import '../scripts/publications-page';
   </script>
 </BaseLayout>
-
-<style>
-  /* Page-specific rules for /publications (moved out of global.css
-     since they aren't used elsewhere). */
-
-  .pub-count {
-    background: var(--color-bg-accent);
-    color: var(--color-accent-primary);
-    padding: var(--space-1) var(--space-3);
-    border-radius: var(--radius-full);
-    font-size: var(--text-xs);
-    font-weight: 600;
-  }
-
-  /* Filter bar */
-  .filter-bar {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-3);
-    padding: var(--space-6) 0;
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
-
-  .filter-chip {
-    padding: var(--space-2) var(--space-4);
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-full);
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
-    cursor: pointer;
-    transition: all var(--transition-fast);
-    font-family: inherit;
-  }
-
-  .filter-chip:hover,
-  .filter-chip.active {
-    background: var(--color-accent-primary);
-    border-color: var(--color-accent-primary);
-    color: white;
-  }
-
-  .search-input {
-    flex: 1;
-    min-width: 200px;
-    padding: var(--space-2) var(--space-4);
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-md);
-    font-size: var(--text-sm);
-    color: var(--color-text-primary);
-    font-family: inherit;
-  }
-
-  .search-input::placeholder {
-    color: var(--color-text-tertiary);
-  }
-
-  .search-input:focus {
-    outline: none;
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 3px var(--color-bg-accent);
-  }
-
-  /* Publications section layout */
-  .publications-section {
-    padding: var(--space-8) 0;
-  }
-
-  .section-label {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    margin-bottom: var(--space-6);
-  }
-
-  .section-label h2 {
-    margin: 0;
-    font-size: var(--text-lg);
-    font-weight: 600;
-    color: var(--color-text-primary);
-  }
-
-  .section-line {
-    flex: 1;
-    height: 1px;
-    background: var(--color-border);
-  }
-
-  /* Per-card pieces that only show up in the full (non-compact) layout */
-  .pub-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: var(--space-4);
-  }
-
-  .pub-year {
-    flex-shrink: 0;
-    padding: var(--space-1) var(--space-3);
-    background: var(--color-bg-tertiary);
-    border-radius: var(--radius-sm);
-    font-size: var(--text-xs);
-    font-weight: 600;
-    color: var(--color-text-tertiary);
-  }
-
-  .publication-authors {
-    margin: 0 0 var(--space-2);
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
-  }
-
-  .publication-authors a {
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    border-bottom: 1px dashed var(--color-border);
-  }
-
-  .publication-authors a:hover {
-    color: var(--color-accent-primary);
-    border-bottom-color: var(--color-accent-primary);
-  }
-
-  .publication-authors .self {
-    font-weight: 600;
-    color: var(--color-text-primary);
-  }
-
-  .publication-venue {
-    margin: 0 0 var(--space-3);
-    font-size: var(--text-sm);
-    font-style: italic;
-    color: var(--color-text-tertiary);
-  }
-
-  .publication-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-    margin-top: var(--space-3);
-  }
-
-  .pub-action {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: var(--space-2) var(--space-4);
-    min-height: 36px;
-    background: var(--color-bg-tertiary);
-    border-radius: var(--radius-sm);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    color: var(--color-text-secondary);
-    text-decoration: none;
-    transition: all var(--transition-fast);
-    cursor: pointer;
-    border: none;
-    font-family: inherit;
-  }
-
-  .pub-action:hover {
-    background: var(--color-bg-accent);
-    color: var(--color-accent-primary);
-  }
-
-  .pub-action.primary {
-    background: var(--color-accent-primary);
-    color: white;
-  }
-
-  .pub-action.primary:hover {
-    background: var(--color-accent-hover);
-  }
-
-  /* Collapsible abstract / bibtex */
-  .collapsible-content {
-    display: grid;
-    grid-template-rows: 0fr;
-    transition: grid-template-rows var(--transition-slow);
-  }
-
-  .collapsible-content.open {
-    grid-template-rows: 1fr;
-  }
-
-  .collapsible-inner {
-    overflow: hidden;
-  }
-
-  .abstract-box,
-  .bibtex-box {
-    margin-top: var(--space-4);
-    padding: var(--space-4);
-    background: var(--color-bg-tertiary);
-    border-radius: var(--radius-md);
-    font-size: var(--text-sm);
-    color: var(--color-text-secondary);
-    line-height: 1.6;
-    text-align: left;
-  }
-
-  .bibtex-box {
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
-
-  .bibtex-box code {
-    display: block;
-  }
-
-  @media (max-width: 640px) {
-    .pub-header {
-      flex-direction: column-reverse;
-      align-items: center;
-      text-align: center;
-      gap: var(--space-2);
-    }
-
-    .pub-year {
-      align-self: center;
-    }
-
-    .publication-authors,
-    .publication-venue {
-      text-align: center;
-    }
-
-    .section-label {
-      justify-content: center;
-    }
-  }
-</style>

--- a/src/pages/wedding.astro
+++ b/src/pages/wedding.astro
@@ -7,9 +7,8 @@ import SimpleFooter from '../components/SimpleFooter.astro';
 <BaseLayout title="Wedding - Joel Weinberger" description="Joel and Sarah's wedding, May 30th, 2010">
   <PageHeader title="Wedding" />
 
-  <main class="container">
-    <section class="section">
-      <div class="bio-content">
+  <main class="subpage-shell">
+    <section class="prose">
         <p>
           On May 30th, 2010, my wonderful wife, Sarah, and I were married at her
           family's ranch in Westlake Village, CA, just outside of Los Angeles. It
@@ -27,7 +26,6 @@ import SimpleFooter from '../components/SimpleFooter.astro';
           from the honeymoon, please look at our
           <a href="https://www.flickr.com/photos/metromoxie/sets/72157624953047064" rel="noopener noreferrer">honeymoon photos on Flickr</a>.
         </p>
-      </div>
     </section>
   </main>
 

--- a/src/scripts/publications-page.ts
+++ b/src/scripts/publications-page.ts
@@ -1,94 +1,32 @@
 /**
- * Client-side state for the publications page: filter chips, search, and
- * deep-link hash highlight. Card visibility is recomputed from state on every
- * change, so filter + search interact correctly without one clobbering the other.
+ * Client-side state for the publications page: per-paper Abstract / BibTeX
+ * toggles + deep-link hash highlight on the timeline.
+ *
+ * Each toggle button has `data-toggle="abstract" | "bibtex"` and is paired with
+ * a sibling `[data-panel="<type>"]` panel inside the same `.tl-paper`. We flip
+ * `[hidden]` rather than CSS display so the panels are also hidden from a11y
+ * trees when collapsed, and update aria-expanded + the visible label in lockstep.
  */
 
-type Filter = 'all' | 'refereed' | 'technical';
-
-interface State {
-  activeFilter: Filter;
-  searchQuery: string;
-}
-
-const state: State = {
-  activeFilter: 'all',
-  searchQuery: '',
-};
-
-const toggleLabels: Record<string, string> = {
+const labelByType: Record<string, string> = {
   abstract: 'Abstract',
   bibtex: 'BibTeX',
 };
-
-function matchesFilter(card: HTMLElement): boolean {
-  if (state.activeFilter === 'all') return true;
-  return card.dataset.type === state.activeFilter;
-}
-
-function matchesSearch(card: HTMLElement): boolean {
-  if (!state.searchQuery) return true;
-  const text = (card.textContent || '').toLowerCase();
-  return text.includes(state.searchQuery);
-}
-
-function applyVisibility() {
-  document.querySelectorAll<HTMLElement>('.publication-card').forEach(card => {
-    card.style.display = matchesFilter(card) && matchesSearch(card) ? '' : 'none';
-  });
-
-  document.querySelectorAll<HTMLElement>('.publications-section').forEach(section => {
-    const hiddenByFilter =
-      state.activeFilter !== 'all' && section.dataset.section !== state.activeFilter;
-    section.style.display = hiddenByFilter ? 'none' : '';
-  });
-}
-
-function setFilter(filter: Filter) {
-  state.activeFilter = filter;
-  document.querySelectorAll<HTMLElement>('.filter-chip').forEach(chip => {
-    chip.classList.toggle('active', chip.dataset.filter === filter);
-  });
-  applyVisibility();
-}
-
-function setSearchQuery(query: string) {
-  state.searchQuery = query.trim().toLowerCase();
-  applyVisibility();
-}
-
-function initFilters() {
-  document.querySelectorAll<HTMLElement>('.filter-chip').forEach(chip => {
-    chip.addEventListener('click', () => {
-      setFilter((chip.dataset.filter || 'all') as Filter);
-    });
-  });
-}
-
-function initSearch() {
-  const input = document.getElementById('pub-search') as HTMLInputElement | null;
-  if (!input) return;
-  let timer: number | undefined;
-  input.addEventListener('input', () => {
-    window.clearTimeout(timer);
-    timer = window.setTimeout(() => setSearchQuery(input.value), 150);
-  });
-}
 
 function initToggles() {
   document.querySelectorAll<HTMLElement>('[data-toggle]').forEach(button => {
     button.addEventListener('click', () => {
       const type = button.getAttribute('data-toggle');
       if (!type) return;
-      const card = button.closest('.publication-card');
-      const wrapper = card?.querySelector<HTMLElement>(`.${type}-wrapper`);
-      if (!wrapper) return;
+      const paper = button.closest<HTMLElement>('.tl-paper');
+      const panel = paper?.querySelector<HTMLElement>(`[data-panel="${type}"]`);
+      if (!panel) return;
 
-      const isOpen = wrapper.classList.contains('open');
-      wrapper.classList.toggle('open');
-      wrapper.setAttribute('aria-hidden', String(isOpen));
+      const isOpen = !panel.hasAttribute('hidden');
+      if (isOpen) panel.setAttribute('hidden', '');
+      else panel.removeAttribute('hidden');
       button.setAttribute('aria-expanded', String(!isOpen));
-      button.textContent = isOpen ? toggleLabels[type] || type : 'Hide';
+      button.textContent = isOpen ? labelByType[type] || type : 'Hide';
     });
   });
 }
@@ -97,31 +35,18 @@ function highlightFromHash() {
   const hash = window.location.hash.slice(1);
   if (!hash) return;
   const target = document.getElementById(hash);
-  if (!target?.classList.contains('publication-card')) return;
+  if (!target?.classList.contains('tl-paper')) return;
 
-  // Clear any filter/search that would hide the deep-linked card, so the
-  // highlight actually lands somewhere visible.
-  const type = (target as HTMLElement).dataset.type as Filter | undefined;
-  if (state.activeFilter !== 'all' && type && state.activeFilter !== type) {
-    setFilter('all');
-  }
-  if (state.searchQuery) {
-    const input = document.getElementById('pub-search') as HTMLInputElement | null;
-    if (input) input.value = '';
-    setSearchQuery('');
-  }
-
+  // Re-trigger animation if the same hash is visited twice in a row.
   target.classList.remove('highlight');
   void target.offsetWidth;
   target.classList.add('highlight');
 
-  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  target.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
 }
 
 function init() {
-  initFilters();
-  initSearch();
   initToggles();
   highlightFromHash();
   window.addEventListener('hashchange', highlightFromHash);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -135,6 +135,18 @@ p { margin: 0 0 1.1em; }
 .topbar nav { display: flex; gap: 1.5rem; flex-wrap: wrap; }
 .topbar nav a[aria-current="page"] { color: var(--ink); }
 
+/* At iPhone-class widths the marque + 4 nav items can't share a row without
+   wrapping the last item awkwardly underneath the right-aligned column.
+   Stack the marque above the nav and left-align the row instead. */
+@media (max-width: 540px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+  .topbar nav { gap: 1rem; }
+}
+
 /* ============================================
    HERO
    ============================================ */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -288,22 +288,20 @@ p { margin: 0 0 1.1em; }
   font-weight: 500;
   margin: 0 0 0.15rem;
   letter-spacing: -0.003em;
-  display: flex;
-  align-items: baseline;
-  gap: 0.6rem;
-  flex-wrap: wrap;
 }
 .pub-title a { color: var(--ink); background: none; padding: 0; }
 .pub-title a:hover { color: var(--accent); }
 
 .pub-venue-inline {
+  display: inline-block;
+  margin-left: 0.5rem;
+  vertical-align: 0.08em;
   font-family: var(--mono);
   font-size: 0.66rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--accent);
   white-space: nowrap;
-  flex-shrink: 0;
 }
 
 .pub-meta {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,166 +1,99 @@
 /* ============================================
-   DESIGN SYSTEM - CSS Custom Properties
+   JOEL WEINBERGER — modern literary direction
+   Cool neutrals, classic serif, generous measure.
+
+   Baked-in tweaks (formerly runtime via prototype Tweaks panel):
+     theme    = paper
+     density  = comfortable (no [data-density] variants)
+     type     = Source Serif 4 / Inter Tight / JetBrains Mono
+     accentHue = 30  (oklch overrides on paper accents)
    ============================================ */
+
 :root {
-  /* Color Palette - Modern, professional with subtle warmth */
-  --color-bg-primary: #fafafa;
-  --color-bg-secondary: #ffffff;
-  --color-bg-tertiary: #f5f5f7;
-  --color-bg-accent: #f0f4ff;
+  /* Paper palette */
+  --paper:       #f4f2ec;
+  --paper-rule:  #d9d3c4;
+  --ink:         #1a2230;
+  --ink-soft:    #4a5468;
+  --ink-faint:   #8a8f9e;
 
-  --color-text-primary: #1a1a2e;
-  --color-text-secondary: #4a4a68;
-  --color-text-tertiary: #64648c;
+  /* Accents — paper theme + accentHue=30 (warm copper) */
+  --accent:      oklch(0.40 0.08 30);
+  --accent-soft: oklch(0.55 0.08 30);
+  --highlight:   #c9a96e;
 
-  --color-accent-primary: #4f46e5;
-  --color-accent-secondary: #6366f1;
-  --color-accent-hover: #4338ca;
+  /* Type stack (Source Serif pairing) */
+  --serif: "Source Serif 4", "Source Serif Pro", Georgia, "Times New Roman", serif;
+  --sans:  "Inter Tight", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --mono:  "JetBrains Mono", "IBM Plex Mono", ui-monospace, monospace;
 
-  --color-border: #e5e5ea;
-  --color-border-subtle: #f0f0f5;
+  --measure:      38rem;
+  --measure-wide: 56rem;
 
-  /* Typography Scale */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
-
-  --text-xs: 0.75rem;
-  --text-sm: 0.875rem;
-  --text-base: 1rem;
-  --text-lg: 1.125rem;
-  --text-xl: 1.25rem;
-  --text-2xl: 1.5rem;
-  --text-3xl: 1.875rem;
-  --text-4xl: 2.25rem;
-
-  /* Spacing Scale */
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.25rem;
-  --space-6: 1.5rem;
-  --space-8: 2rem;
-  --space-10: 2.5rem;
-  --space-12: 3rem;
-  --space-16: 4rem;
-  --space-20: 5rem;
-
-  /* Shadows */
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.07);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.08);
-
-  /* Border Radius */
-  --radius-sm: 0.375rem;
-  --radius-md: 0.5rem;
-  --radius-lg: 0.75rem;
-  --radius-xl: 1rem;
-  --radius-full: 9999px;
-
-  /* Transitions */
-  --transition-fast: 150ms ease;
-  --transition-normal: 200ms ease;
-  --transition-slow: 300ms ease;
+  --t-fast: 160ms ease;
+  --t-norm: 240ms ease;
 }
 
-/* Dark mode support */
+/* Dark-mode mapping — port of the prototype's `ink` theme. */
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg-primary: #0f0f1a;
-    --color-bg-secondary: #1a1a2e;
-    --color-bg-tertiary: #252540;
-    --color-bg-accent: #1e1e3f;
-
-    --color-text-primary: #f5f5f7;
-    --color-text-secondary: #b8b8c8;
-    --color-text-tertiary: #9898b8;
-
-    --color-accent-primary: #818cf8;
-    --color-accent-secondary: #a5b4fc;
-    --color-accent-hover: #6366f1;
-
-    --color-border: #2d2d4a;
-    --color-border-subtle: #1f1f35;
+    --paper:       #161821;
+    --paper-rule:  #2a2f3e;
+    --ink:         #e7e2d4;
+    --ink-soft:    #b3b0a3;
+    --ink-faint:   #7d7c75;
+    --accent:      #c9a96e;
+    --accent-soft: #b08a4a;
+    --highlight:   #8da7c9;
   }
 }
 
-/* ============================================
-   BASE STYLES
-   ============================================ */
-*, *::before, *::after {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
-html {
-  font-size: 16px;
-  scroll-behavior: smooth;
-}
+html { font-size: 17px; -webkit-text-size-adjust: 100%; }
 
 body {
   margin: 0;
-  padding: 0;
-  font-family: var(--font-sans);
-  font-size: var(--text-base);
-  line-height: 1.7;
-  color: var(--color-text-primary);
-  background-color: var(--color-bg-primary);
+  font-family: var(--serif);
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  color: var(--ink);
+  background: var(--paper);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "kern", "liga", "onum";
+  text-rendering: optimizeLegibility;
 }
 
-/* ============================================
-   LAYOUT
-   ============================================ */
-.container {
-  max-width: 720px;
-  margin: 0 auto;
-  padding: 0 var(--space-6);
-}
+::selection { background: var(--accent); color: var(--paper); }
 
-/* ============================================
-   TYPOGRAPHY
-   ============================================ */
-h1, h2, h3, h4, h5, h6 {
-  margin: 0;
-  font-weight: 600;
-  line-height: 1.3;
-  color: var(--color-text-primary);
-}
-
-p {
-  margin: 0 0 var(--space-5);
-}
-
+/* Default link treatment: thin underline that thickens on hover.
+   The pub list, top bar, and timeline opt out via `background:none`. */
 a {
-  color: var(--color-accent-primary);
+  color: var(--ink);
   text-decoration: none;
-  transition: color var(--transition-fast);
+  background-image: linear-gradient(currentColor, currentColor);
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 1px;
+  transition: color var(--t-fast), background-size var(--t-fast);
+  padding-bottom: 1px;
 }
-
 a:hover {
-  color: var(--color-accent-hover);
+  color: var(--accent);
+  background-size: 100% 2px;
 }
 
-/* ============================================
-   FOCUS STYLES (Accessibility)
-   ============================================ */
+p { margin: 0 0 1.1em; }
+
 :focus-visible {
-  outline: 2px solid var(--color-accent-primary);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+:focus:not(:focus-visible) { outline: none; }
 
-/* Remove default focus for mouse users, keep for keyboard */
-:focus:not(:focus-visible) {
-  outline: none;
-}
-
-/* ============================================
-   REDUCED MOTION (Accessibility)
-   ============================================ */
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
+  *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
@@ -169,410 +102,500 @@ a:hover {
 }
 
 /* ============================================
-   HERO SECTION
+   PAGE SHELL
+   ============================================ */
+.shell {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 1rem clamp(1.25rem, 4vw, 2rem) 4rem;
+}
+
+.pubs-page .shell { max-width: var(--measure-wide); }
+
+/* ============================================
+   TOP BAR
+   ============================================ */
+.topbar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.5rem;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--paper-rule);
+}
+.topbar a { color: var(--ink-faint); background: none; padding: 0; }
+.topbar a:hover { color: var(--accent); background: none; }
+.topbar .marque { font-weight: 600; letter-spacing: 0.08em; color: var(--ink); }
+.topbar nav { display: flex; gap: 1.5rem; flex-wrap: wrap; }
+.topbar nav a[aria-current="page"] { color: var(--ink); }
+
+/* ============================================
+   HERO
    ============================================ */
 .hero {
-  padding: var(--space-16) 0 var(--space-10);
-  text-align: center;
+  display: grid;
+  grid-template-columns: 1fr clamp(96px, 14vw, 130px);
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  align-items: start;
+  margin-bottom: 0.5rem;
 }
 
-.hero-title {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-5);
-  margin-bottom: var(--space-6);
-}
-
-.profile-image {
-  width: 100px;
-  height: 125px;
-  border-radius: var(--radius-lg);
-  object-fit: cover;
-  box-shadow: var(--shadow-md);
-  flex-shrink: 0;
-}
+.hero-text { min-width: 0; }
 
 .hero h1 {
-  margin: 0;
-  font-size: var(--text-3xl);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-}
-
-/* ============================================
-   NAVIGATION / QUICK LINKS
-   ============================================ */
-.quick-nav {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--space-3);
-}
-
-.nav-link {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-5);
-  min-height: 44px;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  transition: all var(--transition-fast);
-}
-
-.nav-link:hover {
-  border-color: var(--color-accent-primary);
-  color: var(--color-accent-primary);
-  box-shadow: var(--shadow-sm);
-}
-
-.nav-link.primary {
-  background: var(--color-accent-primary);
-  border-color: var(--color-accent-primary);
-  color: white;
-}
-
-.nav-link.primary:hover {
-  background: var(--color-accent-hover);
-  border-color: var(--color-accent-hover);
-  color: white;
-}
-
-/* ============================================
-   SECTIONS
-   ============================================ */
-.section {
-  padding: var(--space-10) 0;
-  border-top: 1px solid var(--color-border-subtle);
-}
-
-.section-header {
-  margin-bottom: var(--space-6);
-}
-
-.section-title {
-  margin: 0;
-  font-size: var(--text-lg);
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-/* ============================================
-   BIO CONTENT
-   ============================================ */
-.bio-content p {
-  margin: 0 0 var(--space-5);
-  color: var(--color-text-secondary);
-}
-
-.bio-content p:last-child {
-  margin-bottom: 0;
-}
-
-.bio-content a {
-  color: var(--color-accent-primary);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: border-color var(--transition-fast);
-}
-
-.bio-content a:hover {
-  border-bottom-color: var(--color-accent-primary);
-}
-
-.legacy-note {
-  text-align: center;
-  font-size: var(--text-sm);
-  color: var(--color-text-tertiary);
-  margin-top: var(--space-6);
-}
-
-.legacy-note a {
-  color: var(--color-accent-primary);
-  text-decoration: none;
-}
-
-.legacy-note a:hover {
-  text-decoration: underline;
-}
-
-/* ============================================
-   PUBLICATIONS
-   ============================================ */
-.publications-list {
+  margin: 0 0 1.1rem;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2rem, 5.2vw, 3.2rem);
+  line-height: 1.02;
+  letter-spacing: -0.018em;
+  font-feature-settings: "kern", "liga", "lnum";
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  align-items: flex-start;
+}
+.hero h1 .given { display: block; }
+.hero h1 em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+  display: block;
+  /* italic glyphs ride forward on the baseline; pull back so the
+     stem of "W" sits flush with the "J" above */
+  margin-left: -0.06em;
 }
 
-.publications-list.compact {
-  gap: var(--space-3);
+.hero-lede {
+  font-family: var(--serif);
+  font-size: clamp(1.05rem, 1.5vw, 1.2rem);
+  line-height: 1.55;
+  color: var(--ink-soft);
+  max-width: 30rem;
+  margin: 0;
+  text-wrap: pretty;
 }
 
-.publications-list.compact .publication-card {
-  padding: var(--space-3) var(--space-4);
+.headshot {
+  width: 100%;
+  max-width: 130px;
+  height: auto;
+  border-radius: 2px;
+  box-shadow:
+    0 1px 0 rgba(0,0,0,0.05),
+    0 12px 28px -10px rgba(20,30,50,0.22);
+  filter: saturate(0.92);
+  transition: filter var(--t-norm), transform var(--t-norm);
+  margin-top: 0.4rem;
+}
+.headshot:hover { filter: saturate(1); transform: rotate(-0.6deg); }
+
+@media (max-width: 540px) {
+  .hero { grid-template-columns: 1fr; }
+  .headshot { order: -1; width: 110px; }
 }
 
-.publications-list.compact .publication-title {
-  font-size: var(--text-sm);
-  margin-bottom: var(--space-1);
+/* ============================================
+   PROSE / BIO
+   ============================================ */
+.prose {
+  font-size: 1.0625rem;
+  line-height: 1.7;
+  color: var(--ink);
+  max-width: 36rem;
+}
+.prose p { margin: 0 0 1.15em; text-wrap: pretty; }
+.prose p:last-child { margin-bottom: 0; }
+
+/* ============================================
+   SECTION HEADERS
+   ============================================ */
+.section {
+  padding-top: 0.85rem;
+  margin-top: 0.85rem;
+  border-top: 1px solid var(--paper-rule);
+  position: relative;
 }
 
-.publications-list.compact .publication-meta {
-  font-size: var(--text-xs);
-  margin-bottom: 0;
+.section-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.65rem;
 }
-
-.see-all-link {
-  margin-top: var(--space-4);
-  text-align: right;
-  font-size: var(--text-sm);
+.section-label h2 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.4rem, 2.4vw, 1.75rem);
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--ink);
 }
-
-.see-all-link a {
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  transition: color var(--transition-fast);
-}
-
-.see-all-link a:hover {
-  color: var(--color-accent-primary);
-}
-
-.publication-card {
-  padding: var(--space-5);
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
-  transition: all var(--transition-fast);
-}
-
-.publication-card:hover {
-  border-color: var(--color-border);
-  box-shadow: var(--shadow-sm);
-}
-
-.publication-title {
-  margin: 0 0 var(--space-2);
-  font-size: var(--text-base);
+.section-label.prominent h2 {
+  font-size: clamp(1.8rem, 3.2vw, 2.4rem);
+  font-style: normal;
   font-weight: 600;
-  line-height: 1.4;
+  letter-spacing: -0.018em;
 }
-
-.publication-title a {
-  color: var(--color-text-primary);
-  text-decoration: none;
-  transition: color var(--transition-fast);
-}
-
-.publication-title a:hover {
-  color: var(--color-accent-primary);
-}
-
-.publication-meta {
-  margin: 0 0 var(--space-3);
-  font-size: var(--text-sm);
-  color: var(--color-text-tertiary);
-}
-
-.details-link {
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  transition: color var(--transition-fast);
+.section-label.prominent { margin-bottom: 0.85rem; }
+.section-label .meta {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  text-align: right;
   white-space: nowrap;
 }
 
-.details-link:hover {
-  color: var(--color-accent-primary);
-}
-
-@keyframes publication-card-highlight {
-  0%   { box-shadow: 0 0 0 3px var(--color-accent-primary); }
-  100% { box-shadow: none; }
-}
-
-.publication-card.highlight {
-  animation: publication-card-highlight 2.5s ease-out;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .publication-card.highlight {
-    animation: none;
-    box-shadow: 0 0 0 3px var(--color-accent-primary);
-  }
-}
-
 /* ============================================
-   FOOTER
+   FEATURED PUB LIST (homepage)
    ============================================ */
-.footer {
-  padding: var(--space-10) 0;
-  text-align: center;
-  border-top: 1px solid var(--color-border-subtle);
+.pub-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+
+.pub {
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--paper-rule);
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  gap: 1rem;
+  align-items: baseline;
+}
+.pub:last-child { border-bottom: none; }
+
+.pub-year {
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+  font-feature-settings: "tnum";
+  padding-top: 0.18rem;
 }
 
-.footer-links {
+.pub-body { min-width: 0; }
+
+.pub-title {
+  font-family: var(--serif);
+  font-size: 0.98rem;
+  line-height: 1.4;
+  font-weight: 500;
+  margin: 0 0 0.15rem;
+  letter-spacing: -0.003em;
   display: flex;
-  justify-content: center;
+  align-items: baseline;
+  gap: 0.6rem;
   flex-wrap: wrap;
-  gap: var(--space-4);
-  margin-bottom: var(--space-4);
+}
+.pub-title a { color: var(--ink); background: none; padding: 0; }
+.pub-title a:hover { color: var(--accent); }
+
+.pub-venue-inline {
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
-.footer-link {
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  font-size: var(--text-sm);
-  padding: var(--space-2) var(--space-3);
-  transition: color var(--transition-fast);
-}
-
-.footer-link:hover {
-  color: var(--color-accent-primary);
-}
-
-.footer-credit {
-  font-size: var(--text-xs);
-  color: var(--color-text-tertiary);
+.pub-meta {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
   margin: 0;
 }
+.pub-meta a { color: var(--ink-soft); }
 
-.footer-credit a {
-  color: var(--color-text-tertiary);
+.see-more {
+  display: inline-block;
+  margin-top: 1.5rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: none;
+  padding-bottom: 2px;
 }
+.see-more::after { content: " →"; }
 
-.newark-link {
-  display: block;
-  margin-bottom: var(--space-6);
+/* ============================================
+   COLOPHON / FOOTER (homepage)
+   ============================================ */
+.colophon {
+  margin-top: clamp(3rem, 7vw, 5rem);
+  padding-top: 2rem;
+  border-top: 1px solid var(--paper-rule);
+  display: grid;
+  gap: 1.5rem;
+  justify-items: start;
 }
-
-.newark-postcard {
-  width: 180px;
+.newark-link { display: block; line-height: 0; margin: 0 auto; width: fit-content; }
+.newark-img-plain {
+  width: 160px;
   height: auto;
-  border-radius: var(--radius-md);
-  opacity: 0.85;
-  transition: all var(--transition-normal);
-  filter: saturate(0.9);
+  border-radius: 2px;
+  filter: saturate(0.88);
+  transition: filter var(--t-norm), transform var(--t-norm);
+  box-shadow: 0 8px 22px -10px rgba(0,0,0,0.25);
+}
+.newark-img-plain:hover {
+  filter: saturate(1.05);
+  transform: rotate(-1deg);
 }
 
-.newark-postcard:hover {
-  opacity: 1;
-  filter: saturate(1);
-  transform: scale(1.02);
+.colophon-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.15rem 1.5rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.colophon-links a { color: var(--ink-soft); background: none; padding: 0; }
+.colophon-links a:hover { color: var(--accent); }
+
+.colophon-credit {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+}
+.colophon-credit a { color: var(--ink-faint); }
+
+/* ============================================
+   PUBLICATIONS PAGE — chronological timeline
+   ============================================ */
+.pubs-h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  line-height: 1;
+  letter-spacing: -0.022em;
+  margin: 0 0 1.25rem;
+}
+.pubs-h1 em { color: var(--accent); }
+
+.pubs-intro {
+  font-family: var(--serif);
+  font-size: clamp(1.05rem, 1.5vw, 1.2rem);
+  line-height: 1.55;
+  color: var(--ink-soft);
+  max-width: 38rem;
+  margin: 0 0 clamp(2rem, 5vw, 3.5rem);
+  text-wrap: pretty;
+}
+
+.timeline {
+  position: relative;
+  padding-left: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.tl-row {
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  padding: 1rem 0 1.1rem;
+  border-top: 1px solid var(--paper-rule);
+  position: relative;
+}
+.tl-row:first-of-type { border-top: 1px solid var(--ink); }
+
+.year-anchor {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+  font-feature-settings: "lnum", "tnum";
+  padding-top: 0.35rem;
+  align-self: start;
+}
+
+.tl-paper { max-width: 40rem; }
+
+.tl-title {
+  font-family: var(--serif);
+  font-size: clamp(1.15rem, 1.7vw, 1.4rem);
+  line-height: 1.25;
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  margin: 0 0 0.55rem;
+  text-wrap: balance;
+}
+.tl-title a { color: var(--ink); background: none; padding: 0; }
+.tl-title a:hover { color: var(--accent); }
+
+.tl-meta {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink-soft);
+  margin: 0 0 0.85rem;
+  line-height: 1.5;
+}
+.tl-meta .venue-name { font-style: normal; color: var(--ink); }
+
+.tl-abstract {
+  font-size: 0.96rem;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  margin: 0.85rem 0 0;
+  max-width: 36rem;
+  text-wrap: pretty;
+}
+
+.tl-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.1rem;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.tl-actions a {
+  color: var(--ink-soft);
+  background: none;
+  padding-bottom: 1px;
+  border-bottom: 1px solid transparent;
+  transition: color var(--t-fast), border-color var(--t-fast);
+}
+.tl-actions a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.tl-toggle {
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  background: none;
+  border: none;
+  padding: 0 0 1px;
+  border-bottom: 1px solid transparent;
+  cursor: pointer;
+  transition: color var(--t-fast), border-color var(--t-fast);
+}
+.tl-toggle:hover,
+.tl-toggle[aria-expanded="true"] {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.tl-bibtex {
+  margin-top: 0.85rem;
+  padding: 0.9rem 1rem;
+  background: rgba(0,0,0,0.03);
+  border-left: 2px solid var(--paper-rule);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-radius: 2px;
+}
+@media (prefers-color-scheme: dark) {
+  .tl-bibtex { background: rgba(255,255,255,0.025); }
+}
+
+/* Hidden-by-default state for the abstract/bibtex toggles. */
+.tl-paper [hidden] { display: none; }
+
+@media (max-width: 640px) {
+  .tl-row { grid-template-columns: 1fr; gap: 0.4rem; }
+  .year-anchor { padding: 0; }
+}
+
+/* Deep-link highlight (publications page) */
+@keyframes tl-highlight {
+  0%   { background: color-mix(in oklab, var(--accent) 18%, transparent); }
+  100% { background: transparent; }
+}
+.tl-paper.highlight { animation: tl-highlight 2.5s ease-out; }
+@media (prefers-reduced-motion: reduce) {
+  .tl-paper.highlight { animation: none; outline: 2px solid var(--accent); outline-offset: 4px; }
 }
 
 /* ============================================
-   PAGE HEADER (Publications, etc.)
+   SUB-PAGE CHROME (calendar, wedding)
+   Headers and back-links with the same literary feel.
    ============================================ */
 .page-header {
-  padding: var(--space-8) 0;
-  border-bottom: 1px solid var(--color-border-subtle);
+  padding: 1rem clamp(1.25rem, 4vw, 2rem) 0.5rem;
+  max-width: var(--measure);
+  margin: 0 auto;
+  border-bottom: 1px solid var(--paper-rule);
+  margin-bottom: 1rem;
 }
-
-.header-content {
+.page-header .header-content {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: var(--space-4);
+  gap: 1rem;
 }
-
-.header-left {
+.page-header .header-left {
   display: flex;
-  align-items: center;
-  gap: var(--space-4);
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
-
 .back-link {
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  background: none;
+  padding: 0;
   display: inline-flex;
   align-items: center;
-  gap: var(--space-2);
-  color: var(--color-text-tertiary);
-  text-decoration: none;
-  font-size: var(--text-sm);
-  transition: color var(--transition-fast);
+  gap: 0.4rem;
 }
-
-.back-link:hover {
-  color: var(--color-accent-primary);
-}
-
+.back-link:hover { color: var(--accent); background: none; }
 .page-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  letter-spacing: -0.012em;
   margin: 0;
-  font-size: var(--text-2xl);
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  color: var(--ink);
 }
 
-/* ============================================
-   RESPONSIVE
-   ============================================ */
-@media (max-width: 640px) {
-  .hero {
-    padding: var(--space-10) 0 var(--space-8);
-  }
-
-  .hero-title {
-    gap: var(--space-4);
-  }
-
-  .profile-image {
-    width: 80px;
-    height: 100px;
-  }
-
-  .hero h1 {
-    font-size: var(--text-2xl);
-  }
-
-  .section {
-    padding: var(--space-8) 0;
-  }
-
-  .section-header {
-    text-align: center;
-  }
-
-  .quick-nav {
-    gap: var(--space-2);
-  }
-
-  .nav-link {
-    font-size: var(--text-sm);
-    padding: var(--space-2) var(--space-4);
-    min-height: 44px;
-  }
-
-  .publication-card {
-    text-align: center;
-  }
-
-  .publication-actions {
-    justify-content: center;
-  }
-
-  .newark-postcard {
-    width: 140px;
-  }
-
-  /* Publications page responsive */
-  .header-content {
-    justify-content: center;
-  }
-
-  .header-left {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-  }
-
-  .page-title {
-    font-size: var(--text-xl);
-  }
-
+.subpage-shell {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 0 clamp(1.25rem, 4vw, 2rem) 4rem;
 }
+
+.subpage-footer {
+  margin-top: clamp(2.5rem, 6vw, 4rem);
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--paper-rule);
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.subpage-footer a { color: var(--ink-faint); background: none; padding: 0; }
+.subpage-footer a:hover { color: var(--accent); }


### PR DESCRIPTION
Port the literary-direction prototype from `redesign-prototype` into the Astro
site. Single paper theme baked in (no runtime tweaks): `theme=paper`,
`density=comfortable`, `type=Source Serif 4 / Inter Tight / JetBrains Mono`,
`accentHue=30` (copper). The prototype's `ink` theme becomes the
`prefers-color-scheme: dark` mapping.

## What changed

- **Design system** (`src/styles/global.css`): full rewrite. Cool-neutral
  paper palette, copper accent, generous measure (`--measure: 38rem` / wide
  `56rem`), serif-first body, mono caps for chrome (topbar, venue pills,
  action buttons). Drops the `[data-theme]` and `[data-density]` selectors
  the prototype used at runtime.
- **Fonts** (`BaseLayout.astro`): swap `/fonts/fonts.css` (Inter + JetBrains)
  for a single Google Fonts link with preconnect — Source Serif 4
  (400/600 + ital), Inter Tight (400/500/600), JetBrains Mono (400/500).
- **Homepage**: stacked `<h1><span class="given">Joel</span><em>Weinberger</em></h1>`
  with copper italic surname; hero-lede + headshot grid; About / Publications
  (prominent serif header) / Outside work sections separated by hairline rules,
  each with a right-aligned mono meta caption (`BIO`, `PERSONAL`); dense pub
  list with year gutter, inline mono venue pill, "with X and Y" co-authors;
  Newark postcard footer with mono caps social links.
- **Publications page**: replaces the card grid + filter chips + search with a
  flat year-gutter timeline. Refereed papers and tech reports merge into a
  single chronological list. Per-paper PDF / Abstract / BibTeX, where Abstract
  and BibTeX are `[hidden]` panels toggled by sibling `<button class="tl-toggle"
  data-toggle="…">`.
- **Sub-page chrome**: `PageHeader`, `SimpleFooter`, `calendar`, `wedding` all
  re-skinned to the new vars and shell.
- **`pubs.json`**: backfill `year: "2016"` on the W3C SRI Recommendation so
  it sorts alongside the 2016 SOUPS paper instead of falling to the bottom of
  the timeline.
- **`publications.ts`**: add `getCompactVenue(conference)` — prefers a
  parenthesized acronym + 2-digit year (`ESORICS '11`, `HotSec '11`) for the
  homepage's inline pill so long venue strings don't break the title row.
- **Mobile topbar fix**: at ≤540px, stack the marque above the nav and
  left-align everything. The previous one-row layout wrapped `GITHUB`
  underneath with an awkward right-side indent. Desktop layout untouched.

## Commits

Six logical steps, in order:

1. `296c346` New design system: paper theme, Source Serif, copper accent
2. `40d9670` Homepage: stacked Joel/Weinberger hero + dense pub list
3. `80a8ada` Publications: year-gutter timeline with per-paper Abstract/BibTeX toggles
4. `804c3bf` Sub-page chrome: paper-theme PageHeader, SimpleFooter, calendar, wedding
5. `f903c8b` pubs.json: backfill 2016 year on the SRI W3C Recommendation
6. `0415de8` Mobile topbar: stack marque above nav at narrow widths

## Screenshots

Captured via Playwright. Stored on the `redesign-prototype` branch (will be
deleted post-merge, alongside the `redesign-prototype/` directory itself).

Desktop (light / dark, 900×1100 reading viewport):
- [home — light](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/home-light.png)
- [home — dark](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/home-dark.png)
- [publications — light](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-light.png)
- [publications — dark](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-dark.png)
- [publications — first paper's Abstract + BibTeX panels open](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-toggle-open.png)

Mobile (after the topbar fix):
- [iPhone 13 — top](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/mobile/iphone-13-top.png)
- [iPhone 13 — full page](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/mobile/iphone-13-full.png)
- [iPhone 13 — /publications](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/mobile/iphone-13-pubs-top.png)
- [Pixel 7 — top](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/mobile/pixel-7-top.png)

## Test plan

- [x] `npm run build` clean (4 pages: `/`, `/publications`, `/calendar`, `/wedding`)
- [x] `npm run dev` walked through homepage + publications, light + dark
- [x] Per-paper Abstract / BibTeX toggle works; `[hidden]` flips correctly
- [x] Deep-link hash highlight (`/publications#weinberger-felt`) animates the
      target row and scrolls into view
- [x] Mobile topbar stacks cleanly on iPhone 13 + Pixel 7 viewports


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmMDShQye3EB6KSVgtUhFs)_