### PR TITLE
Mobile: stack topbar marque above nav at narrow widths

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -135,6 +135,18 @@ p { margin: 0 0 1.1em; }
 .topbar nav { display: flex; gap: 1.5rem; flex-wrap: wrap; }
 .topbar nav a[aria-current="page"] { color: var(--ink); }
 
+/* At iPhone-class widths the marque + 4 nav items can't share a row without
+   wrapping the last item awkwardly underneath the right-aligned column.
+   Stack the marque above the nav and left-align the row instead. */
+@media (max-width: 540px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+  .topbar nav { gap: 1rem; }
+}
+
 /* ============================================
    HERO
    ============================================ */


### PR DESCRIPTION
Follow-up to #32. The deployed redesign has the topbar trying to fit a `JWW`
marque + 4 mono-caps nav items on a single row at iPhone widths; the nav
wraps `GITHUB` underneath with an awkward right-side indent (because the
`justify-content: space-between` parent keeps the nav pinned to the right,
and items wrap inside that right-side cell).

Stack at ≤540 px: marque on its own line above a left-aligned nav row.
Desktop layout untouched — gated behind the existing mobile breakpoint
already used by the hero (`@media (max-width: 540px)`).

## Before / after

- [Before — deployed iPhone capture](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/uploads/draw-e73793f0-e31e-4dee-91ff-7d15584a0066.png) (the screenshot Joel attached in the redesign chat — `GITHUB` orphaned on a second line, indented under nothing)
- [After — iPhone 13](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/mobile/iphone-13-top.png)
- [After — Pixel 7](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/mobile/pixel-7-top.png)
- [After — /publications on iPhone 13](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/mobile/iphone-13-pubs-top.png)

## Test plan

- [x] `npm run build` clean
- [x] iPhone 13 + Pixel 7 viewports verified via Playwright
- [x] Desktop layout (≥541 px) unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmMDShQye3EB6KSVgtUhFs)_