### PR TITLE
Restore search + filter on /publications, styled in the new design

### DIFF
--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -25,10 +25,13 @@ function authorSeparator(index: number, total: number): string {
   return ', ';
 }
 
-/* Single chronological list — papers + tech reports + the SRI spec, newest first. */
-const all: Paper[] = [...papers, ...techs].sort((a, b) => {
-  return parseInt(getYear(b) || '0') - parseInt(getYear(a) || '0');
-});
+/* Single chronological list — papers + tech reports + the SRI spec, newest first.
+   `_kind` is non-persistent metadata used to drive the Refereed/Technical filter. */
+type ListedPaper = Paper & { _kind: 'refereed' | 'technical' };
+const all: ListedPaper[] = [
+  ...papers.map(p => ({ ...p, _kind: 'refereed' as const })),
+  ...techs.map(p => ({ ...p, _kind: 'technical' as const })),
+].sort((a, b) => parseInt(getYear(b) || '0') - parseInt(getYear(a) || '0'));
 ---
 
 <BaseLayout title="Publications - Joel Weinberger" description="Research publications by Joel Weinberger on web security, browser security, and programming languages.">
@@ -53,15 +56,29 @@ const all: Paper[] = [...papers, ...techs].sort((a, b) => {
         </p>
       </header>
 
+      <div class="pub-controls" role="region" aria-label="Filter and search publications">
+        <div class="filter-chips" role="radiogroup" aria-label="Filter by type">
+          <button type="button" class="chip is-active" data-filter="all" role="radio" aria-checked="true">All <span class="chip-count" data-count="all"></span></button>
+          <button type="button" class="chip" data-filter="refereed" role="radio" aria-checked="false">Refereed <span class="chip-count" data-count="refereed"></span></button>
+          <button type="button" class="chip" data-filter="technical" role="radio" aria-checked="false">Tech Reports <span class="chip-count" data-count="technical"></span></button>
+        </div>
+        <label class="search-field">
+          <span class="visually-hidden">Search publications</span>
+          <input type="search" id="pub-search" placeholder="Search title, author, venue…" autocomplete="off" />
+        </label>
+      </div>
+
+      <p class="pub-empty" hidden>No publications match.</p>
+
       <ol class="timeline">
-        {all.map(p => {
+        {all.map((p, i) => {
           const pdfUrl = getPdfUrl(p);
           const isExternal = p.pdf.startsWith('http');
           const isSpec = p.pdf.includes('w3.org');
           const venue = p.conference ? formatVenue(p.conference) : 'W3C Recommendation';
           const bibtex = generateBibtex(p);
           return (
-            <li class="tl-row">
+            <li class:list={['tl-row', i === 0 && 'is-first']} data-type={p._kind}>
               <div class="year-anchor">{getYear(p)}</div>
               <article class="tl-paper" id={getPaperId(p)}>
                 <h3 class="tl-title">

--- a/src/scripts/publications-page.ts
+++ b/src/scripts/publications-page.ts
@@ -1,17 +1,109 @@
 /**
- * Client-side state for the publications page: per-paper Abstract / BibTeX
- * toggles + deep-link hash highlight on the timeline.
+ * Client-side state for the publications page:
+ *  - per-paper Abstract / BibTeX toggle panels
+ *  - filter chips (All / Refereed / Tech Reports) + free-text search
+ *  - deep-link hash highlight
  *
- * Each toggle button has `data-toggle="abstract" | "bibtex"` and is paired with
- * a sibling `[data-panel="<type>"]` panel inside the same `.tl-paper`. We flip
- * `[hidden]` rather than CSS display so the panels are also hidden from a11y
- * trees when collapsed, and update aria-expanded + the visible label in lockstep.
+ * Filter and search compose: a row is visible only when it matches both, and
+ * either input clears together via state recompute (so changing the filter
+ * doesn't strand a stale search match). Hits the DOM by toggling `[hidden]`
+ * on `.tl-row` so a11y trees stay in sync. The first-visible row gets a
+ * `.is-first` class so the heavier top rule moves with filtering instead of
+ * sitting under a hidden row.
  */
 
-const labelByType: Record<string, string> = {
+type Filter = 'all' | 'refereed' | 'technical';
+
+interface State {
+  filter: Filter;
+  query: string;
+}
+
+const state: State = { filter: 'all', query: '' };
+
+const labelByPanelType: Record<string, string> = {
   abstract: 'Abstract',
   bibtex: 'BibTeX',
 };
+
+const VALID_FILTERS = new Set<Filter>(['all', 'refereed', 'technical']);
+
+const isFilter = (v: string): v is Filter => (VALID_FILTERS as Set<string>).has(v);
+
+function rows(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>('.tl-row'));
+}
+
+function rowMatches(row: HTMLElement): boolean {
+  if (state.filter !== 'all' && row.dataset.type !== state.filter) return false;
+  if (!state.query) return true;
+  return (row.textContent || '').toLowerCase().includes(state.query);
+}
+
+function applyVisibility() {
+  let firstVisible: HTMLElement | null = null;
+  let visible = 0;
+  rows().forEach(row => {
+    const ok = rowMatches(row);
+    row.toggleAttribute('hidden', !ok);
+    row.classList.remove('is-first');
+    if (ok) {
+      visible++;
+      if (!firstVisible) firstVisible = row;
+    }
+  });
+  firstVisible?.classList.add('is-first');
+
+  const empty = document.querySelector<HTMLElement>('.pub-empty');
+  if (empty) empty.toggleAttribute('hidden', visible > 0);
+}
+
+function setCounts() {
+  const all = rows();
+  const counts = {
+    all: all.length,
+    refereed: all.filter(r => r.dataset.type === 'refereed').length,
+    technical: all.filter(r => r.dataset.type === 'technical').length,
+  };
+  document.querySelectorAll<HTMLElement>('[data-count]').forEach(el => {
+    const k = el.dataset.count as keyof typeof counts | undefined;
+    if (k && k in counts) el.textContent = String(counts[k]);
+  });
+}
+
+function setFilter(f: Filter) {
+  state.filter = f;
+  document.querySelectorAll<HTMLElement>('.chip').forEach(chip => {
+    const active = chip.dataset.filter === f;
+    chip.classList.toggle('is-active', active);
+    chip.setAttribute('aria-checked', String(active));
+  });
+  applyVisibility();
+}
+
+function setQuery(q: string) {
+  state.query = q.trim().toLowerCase();
+  applyVisibility();
+}
+
+function initFilters() {
+  document.querySelectorAll<HTMLElement>('.chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      const v = chip.dataset.filter;
+      if (v && isFilter(v)) setFilter(v);
+    });
+  });
+}
+
+function initSearch() {
+  const input = document.getElementById('pub-search') as HTMLInputElement | null;
+  if (!input) return;
+  let timer: number | undefined;
+  input.addEventListener('input', () => {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(() => setQuery(input.value), 120);
+  });
+}
 
 function initToggles() {
   document.querySelectorAll<HTMLElement>('[data-toggle]').forEach(button => {
@@ -23,10 +115,9 @@ function initToggles() {
       if (!panel) return;
 
       const isOpen = !panel.hasAttribute('hidden');
-      if (isOpen) panel.setAttribute('hidden', '');
-      else panel.removeAttribute('hidden');
+      panel.toggleAttribute('hidden', isOpen);
       button.setAttribute('aria-expanded', String(!isOpen));
-      button.textContent = isOpen ? labelByType[type] || type : 'Hide';
+      button.textContent = isOpen ? labelByPanelType[type] || type : 'Hide';
     });
   });
 }
@@ -37,7 +128,19 @@ function highlightFromHash() {
   const target = document.getElementById(hash);
   if (!target?.classList.contains('tl-paper')) return;
 
-  // Re-trigger animation if the same hash is visited twice in a row.
+  // Clear any filter/search that would hide the deep-linked row, so the
+  // highlight actually lands somewhere visible.
+  const row = target.closest<HTMLElement>('.tl-row');
+  const type = row?.dataset.type;
+  if (state.filter !== 'all' && type && state.filter !== type) {
+    setFilter('all');
+  }
+  if (state.query) {
+    const input = document.getElementById('pub-search') as HTMLInputElement | null;
+    if (input) input.value = '';
+    setQuery('');
+  }
+
   target.classList.remove('highlight');
   void target.offsetWidth;
   target.classList.add('highlight');
@@ -47,7 +150,11 @@ function highlightFromHash() {
 }
 
 function init() {
+  setCounts();
+  initFilters();
+  initSearch();
   initToggles();
+  applyVisibility();
   highlightFromHash();
   window.addEventListener('hashchange', highlightFromHash);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -411,7 +411,96 @@ p { margin: 0 0 1.1em; }
   border-top: 1px solid var(--paper-rule);
   position: relative;
 }
-.tl-row:first-of-type { border-top: 1px solid var(--ink); }
+.tl-row.is-first { border-top: 1px solid var(--ink); }
+.tl-row[hidden] { display: none; }
+
+/* ============================================
+   PUB CONTROLS (filter chips + search)
+   ============================================ */
+.pub-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem 1.5rem;
+  padding: 0.65rem 0;
+  margin: 0 0 1.5rem;
+  border-top: 1px solid var(--paper-rule);
+  border-bottom: 1px solid var(--paper-rule);
+}
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.chip {
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  background: transparent;
+  border: 1px solid var(--paper-rule);
+  border-radius: 999px;
+  padding: 0.32rem 0.85rem;
+  cursor: pointer;
+  transition: color var(--t-fast), border-color var(--t-fast), background var(--t-fast);
+}
+.chip:hover { color: var(--accent); border-color: var(--accent); }
+.chip.is-active {
+  color: var(--paper);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.chip-count {
+  font-feature-settings: "tnum", "lnum";
+  margin-left: 0.35rem;
+  opacity: 0.7;
+}
+.chip.is-active .chip-count { color: var(--paper); opacity: 0.85; }
+
+.search-field {
+  flex: 1 1 16rem;
+  display: flex;
+  align-items: center;
+  min-width: 12rem;
+}
+.search-field input {
+  font: inherit;
+  font-family: var(--serif);
+  font-size: 0.95rem;
+  width: 100%;
+  background: transparent;
+  color: var(--ink);
+  border: 0;
+  border-bottom: 1px solid var(--paper-rule);
+  padding: 0.35rem 0;
+  outline: none;
+  transition: border-color var(--t-fast);
+}
+.search-field input::placeholder { color: var(--ink-faint); font-style: italic; }
+.search-field input:focus { border-bottom-color: var(--accent); }
+
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+
+.pub-empty {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-faint);
+  margin: 1.5rem 0;
+  text-align: center;
+}
+
+@media (max-width: 540px) {
+  .pub-controls { gap: 0.6rem 1rem; }
+  .search-field { flex-basis: 100%; }
+}
 
 .year-anchor {
   font-family: var(--mono);


### PR DESCRIPTION
The pre-redesign publications page had filter chips (All / Refereed /
Technical Reports) and free-text search; the redesign dropped both for a flat
chronological timeline. Bring both back, but rendered in the new typographic
vocabulary instead of the old card-grid styling.

## Implementation

- **Markup** (`src/pages/publications.astro`): new `.pub-controls` strip
  between the intro and the timeline — mono-caps chip buttons with per-bucket
  counts on the left, hairline-underlined `<input type="search">` on the
  right. Each `.tl-row` now carries `data-type="refereed" | "technical"` so
  the script can filter without re-querying. The first SSR row gets
  `is-first` directly so the heavy ink rule renders before JS hydrates.
- **Script** (`src/scripts/publications-page.ts`): replaces the toggle-only
  script with a small state machine `{filter, query}`. `applyVisibility()`
  flips `[hidden]` on each row based on both inputs, so chip + search
  compose. The first non-hidden row gets `.is-first` so the heavy top rule
  moves with filtering. Deep-link hash highlight (e.g.
  `/publications#weinberger-felt`) clears any active filter/search that
  would hide the target — same behavior as the old card layout.
- **Styles** (`src/styles/global.css`): `.chip` is an outlined pill in
  `--paper-rule`, mono uppercase, with the active state filled in `--accent`.
  Counts use tabular-num at reduced opacity. `.search-field input` is a
  borderless serif input with a single hairline underline that flips to
  `--accent` on focus. At ≤540px the search field drops to its own row.

## Screenshots

Captured via Playwright; pushed to the `redesign-prototype` branch at
[`screenshots/pubs-controls/`](https://github.com/joelweinberger/personal-website/tree/redesign-prototype/screenshots/pubs-controls).

| state | shot |
| --- | --- |
| Idle (All) | [`idle-top.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/idle-top.png) · [full](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/idle-full.png) |
| Filter: Refereed | [`filter-refereed.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/filter-refereed.png) |
| Filter: Tech Reports | [`filter-technical.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/filter-technical.png) |
| Search "XSS" | [`search-csp.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/search-csp.png) |
| Refereed + "barth" | [`combined.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/combined.png) |
| Empty state | [`empty-state.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/empty-state.png) |
| Dark, idle | [`dark-idle.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/dark-idle.png) |
| Dark, search "integrity" | [`dark-search.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/dark-search.png) |
| iPhone 13, idle | [`mobile-idle-top.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/mobile-idle-top.png) |
| iPhone 13, Tech Reports | [`mobile-filter-technical.png`](https://github.com/joelweinberger/personal-website/blob/redesign-prototype/screenshots/pubs-controls/mobile-filter-technical.png) |

## Test plan

- [x] `npm run build` clean
- [x] Filter chip click narrows the timeline; counts unchanged
- [x] Search debounces (~120ms), filters across title / author / venue text
- [x] Filter + search compose (Refereed + "barth" yields 3 papers)
- [x] Empty state renders italic copy when no rows match
- [x] Deep-link to a hidden row clears state and scrolls to it (e.g.
      `/publications#weinberger-felt` from a Refereed-only state)
- [x] Mobile (≤540px) layout: chips wrap above, search input takes full row
- [x] Dark mode visually verified on all states


---
_Generated by [Claude Code](https://claude.ai/code/session_01BmMDShQye3EB6KSVgtUhFs)_