### PR TITLE
Redesign publications filter bar: inline filter links + hairline search

### DIFF
--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -56,19 +56,23 @@ const all: ListedPaper[] = [
         </p>
       </header>
 
-      <div class="pub-controls" role="region" aria-label="Filter and search publications">
-        <div class="filter-chips" role="radiogroup" aria-label="Filter by type">
-          <button type="button" class="chip is-active" data-filter="all" role="radio" aria-checked="true">All <span class="chip-count" data-count="all"></span></button>
-          <button type="button" class="chip" data-filter="refereed" role="radio" aria-checked="false">Refereed <span class="chip-count" data-count="refereed"></span></button>
-          <button type="button" class="chip" data-filter="technical" role="radio" aria-checked="false">Tech Reports <span class="chip-count" data-count="technical"></span></button>
+      <div class="filter-bar" role="region" aria-label="Filter and search publications">
+        <div class="filter-links" role="radiogroup" aria-label="Filter by type">
+          <button type="button" class="filter-link active" data-filter="all" role="radio" aria-checked="true">All</button>
+          <span class="filter-sep" aria-hidden="true">·</span>
+          <button type="button" class="filter-link" data-filter="refereed" role="radio" aria-checked="false">Refereed</button>
+          <span class="filter-sep" aria-hidden="true">·</span>
+          <button type="button" class="filter-link" data-filter="technical" role="radio" aria-checked="false">Technical reports</button>
         </div>
         <label class="search-field">
+          <span class="search-label" aria-hidden="true">search:</span>
           <span class="visually-hidden">Search publications</span>
-          <input type="search" id="pub-search" placeholder="Search title, author, venue…" autocomplete="off" />
+          <input type="search" id="pub-search" class="search-input" placeholder="title, author, venue…" autocomplete="off" />
         </label>
+        <p class="filter-count" aria-live="polite"></p>
       </div>
 
-      <p class="pub-empty" hidden>No publications match.</p>
+      <p class="empty-state" hidden>No publications match.</p>
 
       <ol class="timeline">
         {all.map((p, i) => {

--- a/src/scripts/publications-page.ts
+++ b/src/scripts/publications-page.ts
@@ -41,9 +41,10 @@ function rowMatches(row: HTMLElement): boolean {
 }
 
 function applyVisibility() {
+  const all = rows();
   let firstVisible: HTMLElement | null = null;
   let visible = 0;
-  rows().forEach(row => {
+  all.forEach(row => {
     const ok = rowMatches(row);
     row.toggleAttribute('hidden', !ok);
     row.classList.remove('is-first');
@@ -54,29 +55,23 @@ function applyVisibility() {
   });
   firstVisible?.classList.add('is-first');
 
-  const empty = document.querySelector<HTMLElement>('.pub-empty');
+  const empty = document.querySelector<HTMLElement>('.empty-state');
   if (empty) empty.toggleAttribute('hidden', visible > 0);
-}
 
-function setCounts() {
-  const all = rows();
-  const counts = {
-    all: all.length,
-    refereed: all.filter(r => r.dataset.type === 'refereed').length,
-    technical: all.filter(r => r.dataset.type === 'technical').length,
-  };
-  document.querySelectorAll<HTMLElement>('[data-count]').forEach(el => {
-    const k = el.dataset.count as keyof typeof counts | undefined;
-    if (k && k in counts) el.textContent = String(counts[k]);
-  });
+  const count = document.querySelector<HTMLElement>('.filter-count');
+  if (count) {
+    count.textContent = visible === all.length
+      ? `${all.length} publication${all.length === 1 ? '' : 's'}`
+      : `${visible} of ${all.length}`;
+  }
 }
 
 function setFilter(f: Filter) {
   state.filter = f;
-  document.querySelectorAll<HTMLElement>('.chip').forEach(chip => {
-    const active = chip.dataset.filter === f;
-    chip.classList.toggle('is-active', active);
-    chip.setAttribute('aria-checked', String(active));
+  document.querySelectorAll<HTMLElement>('.filter-link').forEach(link => {
+    const active = link.dataset.filter === f;
+    link.classList.toggle('active', active);
+    link.setAttribute('aria-checked', String(active));
   });
   applyVisibility();
 }
@@ -87,9 +82,9 @@ function setQuery(q: string) {
 }
 
 function initFilters() {
-  document.querySelectorAll<HTMLElement>('.chip').forEach(chip => {
-    chip.addEventListener('click', () => {
-      const v = chip.dataset.filter;
+  document.querySelectorAll<HTMLElement>('.filter-link').forEach(link => {
+    link.addEventListener('click', () => {
+      const v = link.dataset.filter;
       if (v && isFilter(v)) setFilter(v);
     });
   });
@@ -150,7 +145,6 @@ function highlightFromHash() {
 }
 
 function init() {
-  setCounts();
   initFilters();
   initSearch();
   initToggles();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -427,91 +427,107 @@ p { margin: 0 0 1.1em; }
 .tl-row[hidden] { display: none; }
 
 /* ============================================
-   PUB CONTROLS (filter chips + search)
+   PUB CONTROLS — inline filter links + hairline search
    ============================================ */
-.pub-controls {
+.filter-bar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 0.85rem 1.5rem;
-  padding: 0.65rem 0;
-  margin: 0 0 1.5rem;
-  border-top: 1px solid var(--paper-rule);
+  align-items: baseline;
+  justify-content: space-between;
+  column-gap: 1.5rem;
+  row-gap: 0.5rem;
+  margin: 0 0 1rem;
+  padding-bottom: 0.75rem;
   border-bottom: 1px solid var(--paper-rule);
 }
 
-.filter-chips {
+.filter-links {
   display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
   flex-wrap: wrap;
-  gap: 0.4rem;
 }
 
-.chip {
-  font: inherit;
-  font-family: var(--mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--ink-soft);
-  background: transparent;
-  border: 1px solid var(--paper-rule);
-  border-radius: 999px;
-  padding: 0.32rem 0.85rem;
-  cursor: pointer;
-  transition: color var(--t-fast), border-color var(--t-fast), background var(--t-fast);
-}
-.chip:hover { color: var(--accent); border-color: var(--accent); }
-.chip.is-active {
-  color: var(--paper);
-  background: var(--accent);
-  border-color: var(--accent);
-}
-.chip-count {
-  font-feature-settings: "tnum", "lnum";
-  margin-left: 0.35rem;
-  opacity: 0.7;
-}
-.chip.is-active .chip-count { color: var(--paper); opacity: 0.85; }
-
-.search-field {
-  flex: 1 1 16rem;
-  display: flex;
-  align-items: center;
-  min-width: 12rem;
-}
-.search-field input {
+.filter-link {
   font: inherit;
   font-family: var(--serif);
-  font-size: 0.95rem;
-  width: 100%;
-  background: transparent;
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-soft);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  border-bottom: 1px solid transparent;
+  transition: color var(--t-fast), border-color var(--t-fast);
+  line-height: 1.2;
+}
+.filter-link:hover { color: var(--accent); }
+.filter-link.active {
+  font-style: normal;
   color: var(--ink);
-  border: 0;
+  border-bottom-color: var(--accent);
+}
+
+.filter-sep {
+  font-family: var(--serif);
+  color: var(--ink-faint);
+  font-size: 1rem;
+  user-select: none;
+}
+
+.search-field {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex: 0 1 auto;
+  margin-left: auto;
+}
+.search-label {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.search-input {
+  width: clamp(10rem, 22vw, 16rem);
+  font: inherit;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--ink);
+  background: transparent;
+  border: none;
   border-bottom: 1px solid var(--paper-rule);
-  padding: 0.35rem 0;
+  padding: 0.15rem 0.1rem;
   outline: none;
   transition: border-color var(--t-fast);
 }
-.search-field input::placeholder { color: var(--ink-faint); font-style: italic; }
-.search-field input:focus { border-bottom-color: var(--accent); }
+.search-input::placeholder { color: var(--ink-faint); font-style: italic; }
+.search-input:focus { border-bottom-color: var(--accent); }
+
+.filter-count {
+  flex-basis: 100%;
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+}
+
+.empty-state {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-faint);
+  padding: 2rem 0;
+}
 
 .visually-hidden {
   position: absolute; width: 1px; height: 1px;
   padding: 0; margin: -1px; overflow: hidden;
   clip: rect(0 0 0 0); white-space: nowrap; border: 0;
-}
-
-.pub-empty {
-  font-family: var(--serif);
-  font-style: italic;
-  color: var(--ink-faint);
-  margin: 1.5rem 0;
-  text-align: center;
-}
-
-@media (max-width: 540px) {
-  .pub-controls { gap: 0.6rem 1rem; }
-  .search-field { flex-basis: 100%; }
 }
 
 .year-anchor {


### PR DESCRIPTION
## Summary

Replaces the pill-shaped filter chips and bordered search field on `/publications` with the literary treatment from the design handoff:

- Filters become italic serif text links (`All · Refereed · Technical reports`), separated by serif mid-dots. Active filter is roman-weight ink with a 1px accent underline.
- Search field is small and right-aligned, with a mono-caps `search:` label and a 1px hairline bottom rule. Italic serif input. Placeholder shortened to `title, author, venue…`.
- A new live result count ("12 of 23" or "23 publications") sits on its own row below the bar (`aria-live="polite"`, mono caps, ink-faint).
- Filter bar wraps cleanly on narrow viewports.

Per-paper actions (`PDF · Abstract · BibTeX`) and toggle behavior are unchanged. The search-debounce, radio-group semantics, hash deep-link reset, and dark-mode palette are all preserved.

## Test plan
- [x] `npm run build` succeeds
- [x] Filter clicks update count and visibility (All / Refereed / Technical reports)
- [x] Search filters across title, author, venue, and abstract; empty-state shows on no matches
- [x] Per-paper Abstract / BibTeX toggles flip label to "Hide" and mirror `aria-expanded`
- [x] Hash deep-link (`#paper-id`) resets stale filter/search and lands on the target row
- [x] Mobile viewport (375px) wraps without overflow
- [x] Dark mode (`prefers-color-scheme: dark`) renders with the ink palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)